### PR TITLE
chore: Fix entity configuration

### DIFF
--- a/apps/io-func-wallet-solution-backend/local.settings.json.example
+++ b/apps/io-func-wallet-solution-backend/local.settings.json.example
@@ -12,6 +12,7 @@
     "FederationEntityPolicyUri": "FEDERATION_ENTITY_PRIVACY_URI",
     "FederationEntityTosUri": "FEDERATION_ENTITY_TOS_URI",
     "FederationEntityLogoUri": "FEDERATION_ENTITY_LOGO_URI"
+    "FederationEntityTrustAnchorUri": "FEDERATION_ENTITY_TUST_ANCHOR_URI",
     "WalletKeys": "ARRAY_OF_WALLET_KEYS_IN_JWK_FORMAT_BASE64_ENCODED"
   }
 }

--- a/apps/io-func-wallet-solution-backend/local.settings.json.example
+++ b/apps/io-func-wallet-solution-backend/local.settings.json.example
@@ -12,7 +12,7 @@
     "FederationEntityPolicyUri": "FEDERATION_ENTITY_PRIVACY_URI",
     "FederationEntityTosUri": "FEDERATION_ENTITY_TOS_URI",
     "FederationEntityLogoUri": "FEDERATION_ENTITY_LOGO_URI"
-    "FederationEntityTrustAnchorUri": "FEDERATION_ENTITY_TUST_ANCHOR_URI",
+    "FederationEntityTrustAnchorUri": "FEDERATION_ENTITY_TRUST_ANCHOR_URI",
     "WalletKeys": "ARRAY_OF_WALLET_KEYS_IN_JWK_FORMAT_BASE64_ENCODED"
   }
 }

--- a/apps/io-func-wallet-solution-backend/src/app/config.ts
+++ b/apps/io-func-wallet-solution-backend/src/app/config.ts
@@ -50,6 +50,7 @@ const getFederationEntityConfigFromEnvironment: RE.ReaderEither<
     policyUri: readFromEnvironment("FederationEntityPolicyUri"),
     tosUri: readFromEnvironment("FederationEntityTosUri"),
     logoUri: readFromEnvironment("FederationEntityLogoUri"),
+    trustAnchorUri: readFromEnvironment("FederationEntityTrustAnchorUri"),
   }),
   RE.chainEitherKW(
     validate(

--- a/apps/io-func-wallet-solution-backend/src/encoders/entity-configuration.ts
+++ b/apps/io-func-wallet-solution-backend/src/encoders/entity-configuration.ts
@@ -6,9 +6,15 @@ import { EntityConfigurationPayload } from "../entity-configuration";
 export const EntityConfigurationJwtModel = t.type({
   iss: t.string,
   sub: t.string,
+  authority_hints: t.string,
+  jwks: t.type({
+    keys: t.array(JwkPublicKey),
+  }),
   metadata: t.type({
-    eudi_wallet_provider: t.type({
-      jwks: t.array(JwkPublicKey),
+    wallet_provider: t.type({
+      jwks: t.type({
+        keys: t.array(JwkPublicKey),
+      }),
       token_endpoint: t.string,
       asc_values_supported: t.array(t.string),
       grant_types_supported: t.array(t.string),
@@ -35,9 +41,15 @@ export const EntityConfigurationToJwtModel: E.Encoder<
   encode: ({ iss, sub, walletProviderMetadata, federationEntity }) => ({
     iss,
     sub,
+    authority_hints: federationEntity.trustAnchorUri,
+    jwks: {
+      keys: walletProviderMetadata.jwks,
+    },
     metadata: {
-      eudi_wallet_provider: {
-        jwks: walletProviderMetadata.jwks,
+      wallet_provider: {
+        jwks: {
+          keys: walletProviderMetadata.jwks,
+        },
         token_endpoint: walletProviderMetadata.tokenEndpoint,
         asc_values_supported: walletProviderMetadata.ascValues,
         grant_types_supported: walletProviderMetadata.grantTypesSupported,

--- a/apps/io-func-wallet-solution-backend/src/encoders/entity-configuration.ts
+++ b/apps/io-func-wallet-solution-backend/src/encoders/entity-configuration.ts
@@ -6,7 +6,7 @@ import { EntityConfigurationPayload } from "../entity-configuration";
 export const EntityConfigurationJwtModel = t.type({
   iss: t.string,
   sub: t.string,
-  authority_hints: t.string,
+  authority_hints: t.array(t.string),
   jwks: t.type({
     keys: t.array(JwkPublicKey),
   }),
@@ -41,7 +41,7 @@ export const EntityConfigurationToJwtModel: E.Encoder<
   encode: ({ iss, sub, walletProviderMetadata, federationEntity }) => ({
     iss,
     sub,
-    authority_hints: federationEntity.trustAnchorUri,
+    authority_hints: [federationEntity.trustAnchorUri],
     jwks: {
       keys: walletProviderMetadata.jwks,
     },

--- a/apps/io-func-wallet-solution-backend/src/encoders/wallet-instance-attestation.ts
+++ b/apps/io-func-wallet-solution-backend/src/encoders/wallet-instance-attestation.ts
@@ -46,7 +46,7 @@ export const WalletInstanceAttestationToJwtModel: E.Encoder<
     type,
     federationEntity,
     asc,
-    publicJwk,
+    walletInstancePublicKey,
     algValueSupported,
   }) => ({
     iss,
@@ -58,7 +58,7 @@ export const WalletInstanceAttestationToJwtModel: E.Encoder<
     logo_uri: federationEntity.logoUri,
     asc,
     cnf: {
-      jwk: publicJwk,
+      jwk: walletInstancePublicKey,
     },
     authorization_endpoint: "eudiw",
     response_types_supported: ["vp_token"],

--- a/apps/io-func-wallet-solution-backend/src/entity-configuration.ts
+++ b/apps/io-func-wallet-solution-backend/src/entity-configuration.ts
@@ -27,6 +27,7 @@ export const FederationEntityMetadata = t.type({
   policyUri: UrlFromString,
   tosUri: UrlFromString,
   logoUri: UrlFromString,
+  trustAnchorUri: UrlFromString,
 });
 
 export type FederationEntityMetadata = t.TypeOf<
@@ -44,6 +45,7 @@ export const FederationEntity = t.type({
   policyUri: t.string,
   tosUri: t.string,
   logoUri: t.string,
+  trustAnchorUri: t.string,
 });
 
 const WalletProviderMetadataPayload = t.type({
@@ -106,6 +108,7 @@ export const getEntityConfiguration =
               policyUri: federationEntityMetadata.policyUri.href,
               tosUri: federationEntityMetadata.tosUri.href,
               logoUri: federationEntityMetadata.logoUri.href,
+              trustAnchorUri: federationEntityMetadata.trustAnchorUri.href,
             },
           },
           EntityConfigurationToJwtModel.encode,

--- a/apps/io-func-wallet-solution-backend/src/infra/http/handlers/__test__/create-wallet-instance-attestation.spec.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/http/handlers/__test__/create-wallet-instance-attestation.spec.ts
@@ -50,6 +50,9 @@ const federationEntityMetadata: FederationEntityMetadata = {
   logoUri: new URL(
     "https://wallet-provider.example.org/logo.svg"
   ) as unknown as ValidUrl,
+  trustAnchorUri: new URL(
+    "https://trust-anchor.example.org/logo.svg"
+  ) as unknown as ValidUrl,
 };
 
 describe("CreateWalletInstanceAttestationHandler", async () => {

--- a/apps/io-func-wallet-solution-backend/src/wallet-instance-attestation.ts
+++ b/apps/io-func-wallet-solution-backend/src/wallet-instance-attestation.ts
@@ -20,7 +20,7 @@ export const WalletInstanceAttestationPayload = t.type({
   type: t.literal("WalletInstanceAttestation"),
   federationEntity: FederationEntity,
   asc: t.string,
-  publicJwk: JwkPublicKey,
+  walletInstancePublicKey: JwkPublicKey,
   algValueSupported: t.array(t.string),
 });
 
@@ -60,7 +60,7 @@ export const createWalletInstanceAttestation =
               logoUri: federationEntityMetadata.logoUri.href,
             },
             asc: pipe(federationEntityMetadata.basePath, getLoAUri(LoA.basic)),
-            publicJwk,
+            walletInstancePublicKey: request.payload.cnf.jwk,
             algValueSupported: supportedSignAlgorithms,
           },
           WalletInstanceAttestationToJwtModel.encode,

--- a/apps/io-func-wallet-solution-backend/src/wallet-instance-attestation.ts
+++ b/apps/io-func-wallet-solution-backend/src/wallet-instance-attestation.ts
@@ -58,6 +58,7 @@ export const createWalletInstanceAttestation =
               policyUri: federationEntityMetadata.policyUri.href,
               tosUri: federationEntityMetadata.tosUri.href,
               logoUri: federationEntityMetadata.logoUri.href,
+              trustAnchorUri: federationEntityMetadata.trustAnchorUri.href,
             },
             asc: pipe(federationEntityMetadata.basePath, getLoAUri(LoA.basic)),
             walletInstancePublicKey: request.payload.cnf.jwk,


### PR DESCRIPTION
Minor changes to fully support `OIDC federation` protocol and [trust anchor](https://github.com/italia/spid-cie-oidc-django/tree/main/examples/wallet_trust_anchor/tutorial) compatibility.

The technical rules have also been updated: https://github.com/italia/eudi-wallet-it-docs/pull/90

#### List of Changes
- Added global JWKs according to [section 3.1](https://openid.net/specs/openid-connect-federation-1_0.html#section-3.1-8)
- Added `authority_hints` with trust anchor endpoint.
- Added `FederationEntityTrustAnchorUri` to configuration


#### How Has This Been Tested?
unit tested and on cloud


#### Checklist:
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
