### PR TITLE
feat: Add trust anchor interface

### DIFF
--- a/apps/io-func-wallet-solution-backend/src/infra/trust-anchor/index.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/trust-anchor/index.ts
@@ -1,0 +1,113 @@
+import { pipe, flow } from "fp-ts/function";
+import * as E from "fp-ts/lib/Either";
+import * as TE from "fp-ts/lib/TaskEither";
+import * as jose from "jose";
+
+import { agent } from "@pagopa/ts-commons";
+import {
+  AbortableFetch,
+  setFetchTimeout,
+  toFetch,
+} from "@pagopa/ts-commons/lib/fetch";
+import { Millisecond } from "@pagopa/ts-commons/lib/units";
+
+import {
+  EntityStatementHeader,
+  EntityStatementPayload,
+  TrustAnchor,
+  TrustAnchorEntityConfigurationPayload,
+} from "../../trust-anchor";
+import { FederationEntityMetadata } from "../../entity-configuration";
+import { validate } from "../../validation";
+import { getKeyByKid } from "../../jwk";
+import { verifyJwtSignature } from "../../verifier";
+
+export class EidasTrustAnchor implements TrustAnchor {
+  #configuration: FederationEntityMetadata;
+
+  httpApiFetch = agent.getHttpFetch(process.env);
+  abortableFetch = AbortableFetch(this.httpApiFetch);
+  fetchWithTimeout = toFetch(
+    setFetchTimeout(1000 as Millisecond, this.abortableFetch)
+  ) as unknown as typeof fetch;
+
+  constructor(cnf: FederationEntityMetadata) {
+    this.#configuration = cnf;
+  }
+
+  getPublicKeys = () => {
+    const metadataUrl = new URL(
+      "/.well-known/openid-federation",
+      this.#configuration.trustAnchorUri.href
+    );
+    return pipe(
+      metadataUrl.href,
+      getRequest(this.fetchWithTimeout),
+      TE.map(jose.decodeJwt),
+      TE.chainEitherKW(
+        validate(
+          TrustAnchorEntityConfigurationPayload,
+          "Invalid trust anchor entity configuration"
+        )
+      ),
+      TE.map((metadata) => metadata.jwks.keys)
+    );
+  };
+
+  getEntityStatement = () => {
+    const fetchUrl = new URL("fetch", this.#configuration.trustAnchorUri.href);
+    fetchUrl.searchParams.append("sub", this.#configuration.basePath.href);
+    fetchUrl.searchParams.append(
+      "anchor",
+      this.#configuration.trustAnchorUri.href
+    );
+
+    return pipe(
+      fetchUrl.href,
+      getRequest(this.fetchWithTimeout),
+      TE.chain(this.validateEntityStatementJwt)
+    );
+  };
+
+  validateEntityStatementJwt = (jwt: string) =>
+    pipe(
+      jwt,
+      jose.decodeProtectedHeader,
+      validate(
+        EntityStatementHeader,
+        "Invalid trust anchor entity statement header"
+      ),
+      TE.fromEither,
+      TE.chain((es) =>
+        pipe(
+          this.getPublicKeys(),
+          TE.chain(
+            flow(
+              getKeyByKid(es.kid),
+              TE.fromOption(() => new Error("Kid not found"))
+            )
+          )
+        )
+      ),
+      TE.chain(verifyJwtSignature(jwt)),
+      TE.map((decoded) => decoded.payload),
+      TE.chainEitherKW(
+        validate(
+          EntityStatementPayload,
+          "Invalid trust anchor entity statement payload"
+        )
+      )
+    );
+}
+
+const getRequest = (fetchFunction: typeof fetch) => (url: string) =>
+  pipe(
+    TE.tryCatch(() => fetchFunction(url), E.toError),
+    TE.chain((response) =>
+      response.status === 200
+        ? TE.tryCatch(() => response.text(), E.toError)
+        : TE.left(
+            new Error(`Invalid response from trust anchor: ${response.status}`)
+          )
+    )
+  );

--- a/apps/io-func-wallet-solution-backend/src/infra/trust-anchor/index.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/trust-anchor/index.ts
@@ -37,7 +37,7 @@ export class EidasTrustAnchor implements TrustAnchor {
     this.#configuration = cnf;
   }
 
-   getPublicKeys = () =>
+  getPublicKeys = () =>
     pipe(
       new URL(oidFederation, this.#configuration.trustAnchorUri.href),
       (metadataUrl) => metadataUrl.href,
@@ -52,7 +52,7 @@ export class EidasTrustAnchor implements TrustAnchor {
       TE.map((metadata) => metadata.jwks.keys)
     );
 
- getEntityStatement = () =>
+  getEntityStatement = () =>
     pipe(
       this.#configuration.trustAnchorUri.href,
       (href) => {

--- a/apps/io-func-wallet-solution-backend/src/trust-anchor.ts
+++ b/apps/io-func-wallet-solution-backend/src/trust-anchor.ts
@@ -1,0 +1,51 @@
+import * as t from "io-ts";
+import * as TE from "fp-ts/TaskEither";
+
+import { JwkPublicKey, JwksMetadata } from "./jwk";
+
+export const TrustAnchorEntityConfigurationPayload = t.type({
+  iss: t.string,
+  sub: t.string,
+  jwks: JwksMetadata,
+  iat: t.number,
+  exp: t.number,
+  metadata: t.type({
+    federation_entity: t.type({
+      federation_fetch_endpoint: t.string,
+      federation_resolve_endpoint: t.string,
+      federation_trust_mark_status_endpoint: t.string,
+      homepage_uri: t.string,
+      name: t.string,
+      federation_list_endpoint: t.string,
+    }),
+  }),
+});
+export type TrustAnchorEntityConfigurationPayload = t.TypeOf<
+  typeof TrustAnchorEntityConfigurationPayload
+>;
+
+export const TrustMark = t.type({ id: t.string, trust_mark: t.string });
+export type TrustMark = t.TypeOf<typeof TrustMark>;
+
+export const EntityStatementHeader = t.type({
+  typ: t.literal("entity-statement+jwt"),
+  alg: t.string,
+  kid: t.string,
+});
+export type EntityStatementHeader = t.TypeOf<typeof EntityStatementHeader>;
+
+export const EntityStatementPayload = t.type({
+  iss: t.string,
+  sub: t.string,
+  jwks: JwksMetadata,
+  trust_marks: t.array(TrustMark),
+  iat: t.number,
+  exp: t.number,
+});
+
+export type EntityStatementPayload = t.TypeOf<typeof EntityStatementPayload>;
+
+export type TrustAnchor = {
+  getPublicKeys: () => TE.TaskEither<Error, JwkPublicKey[]>;
+  getEntityStatement: () => TE.TaskEither<Error, EntityStatementPayload>;
+};

--- a/apps/io-func-wallet-solution-backend/src/wallet-instance-attestation.ts
+++ b/apps/io-func-wallet-solution-backend/src/wallet-instance-attestation.ts
@@ -65,7 +65,10 @@ export const createWalletInstanceAttestation =
             algValueSupported: supportedSignAlgorithms,
           },
           WalletInstanceAttestationToJwtModel.encode,
-          signer.createJwtAndsign({ typ: "va+jwt", x5c: [] }, publicJwk.kid)
+          signer.createJwtAndsign(
+            { typ: "va+jwt", x5c: [], trust_chain: [] },
+            publicJwk.kid
+          )
         )
       )
     );

--- a/apps/io-func-wallet-solution-backend/tsconfig.json
+++ b/apps/io-func-wallet-solution-backend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2021", "DOM"],
     "module": "commonjs",
     "target": "ES2021",
     "moduleResolution": "node",


### PR DESCRIPTION
Adds the interface to talk to the trust anchor and get the entity configuration.

#### List of Changes
- Added trust anchor infra
- Added trust anchor types

#### Motivation and Context
Useful interfaces for obtaining the trust chain

#### How Has This Been Tested?
Tested locally


#### Checklist:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
