### PR TITLE
added revoke previous wallet instances after inserting a new one

### DIFF
--- a/apps/io-func-wallet-solution-backend/src/infra/azure/cosmos/wallet-instance.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/azure/cosmos/wallet-instance.ts
@@ -1,8 +1,10 @@
-import { Container, Database } from "@azure/cosmos";
+import { Container, Database, PatchOperationInput } from "@azure/cosmos";
 import * as E from "fp-ts/Either";
 import * as TE from "fp-ts/TaskEither";
-import { pipe } from "fp-ts/function";
+import { flow, pipe } from "fp-ts/function";
+import * as t from "io-ts";
 import { WalletInstance, WalletInstanceRepository } from "@/wallet-instance";
+import { validate } from "@/validation";
 
 export class CosmosDbWalletInstanceRepository
   implements WalletInstanceRepository
@@ -39,6 +41,66 @@ export class CosmosDbWalletInstanceRepository
         await this.#container.items.create(walletInstance);
       },
       (error) => new Error(`Error inserting wallet instance: ${error}`)
+    );
+  }
+
+  getAllByUserId(userId: WalletInstance["userId"]) {
+    return pipe(
+      TE.tryCatch(
+        async () => {
+          const { resources: items } = await this.#container.items
+            .query({
+              query: "SELECT * FROM c WHERE c.userId = @partitionKey",
+              parameters: [
+                {
+                  name: "@partitionKey",
+                  value: userId,
+                },
+              ],
+            })
+            .fetchAll();
+          return items;
+        },
+        (error) =>
+          new Error(`Error getting wallet instances by user id: ${error}`)
+      ),
+      TE.chainW(
+        flow(
+          validate(t.array(WalletInstance), "Invalid wallet instances"),
+          TE.fromEither
+        )
+      )
+    );
+  }
+
+  batchPatchWithReplaceOperation(
+    operationsInput: Array<{
+      id: string;
+      path: string;
+      value: unknown;
+    }>,
+    userId: string
+  ) {
+    return TE.tryCatch(
+      async () => {
+        const operations: PatchOperationInput[] = operationsInput.map(
+          ({ id, path, value }) => ({
+            operationType: "Patch",
+            id,
+            resourceBody: {
+              operations: [
+                {
+                  op: "replace",
+                  path,
+                  value,
+                },
+              ],
+            },
+          })
+        );
+        await this.#container.items.batch(operations, userId);
+      },
+      (error) => new Error(`Error updating wallet instances: ${error}`)
     );
   }
 }

--- a/apps/io-func-wallet-solution-backend/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
@@ -65,6 +65,8 @@ const walletInstanceRepository: WalletInstanceRepository = {
       signCount: 0,
       isRevoked: false,
     }),
+  batchPatchWithReplaceOperation: () => TE.left(new Error("not implemented")),
+  getAllByUserId: () => TE.left(new Error("not implemented")),
 };
 
 const data = Buffer.from(assertion, "base64");

--- a/apps/io-func-wallet-solution-backend/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
@@ -31,6 +31,8 @@ describe("CreateWalletInstanceHandler", () => {
   const walletInstanceRepository: WalletInstanceRepository = {
     insert: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
+    batchPatchWithReplaceOperation: () => TE.right(undefined),
+    getAllByUserId: () => TE.right([]),
   };
 
   const logger = {
@@ -204,6 +206,9 @@ describe("CreateWalletInstanceHandler", () => {
       {
         insert: () => TE.left(new Error("failed on insert!")),
         get: () => TE.left(new Error("not implemented")),
+        batchPatchWithReplaceOperation: () =>
+          TE.left(new Error("not implemented")),
+        getAllByUserId: () => TE.left(new Error("not implemented")),
       };
     const req = {
       ...H.request("https://wallet-provider.example.org"),
@@ -220,6 +225,81 @@ describe("CreateWalletInstanceHandler", () => {
       attestationServiceConfiguration,
       nonceRepository,
       walletInstanceRepository: walletInstanceRepositoryThatFailsOnInsert,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        statusCode: 500,
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+      }),
+    });
+  });
+
+  it("should return a 500 HTTP response on getAllByUserId error", async () => {
+    const walletInstanceRepositoryThatFailsOnGetAllByUserId: WalletInstanceRepository =
+      {
+        insert: () => TE.left(new Error("not implemented")),
+        get: () => TE.left(new Error("not implemented")),
+        batchPatchWithReplaceOperation: () =>
+          TE.left(new Error("not implemented")),
+        getAllByUserId: () => TE.left(new Error("failed on getAllByUserId!")),
+      };
+    const req = {
+      ...H.request("https://wallet-provider.example.org"),
+      method: "POST",
+      body: walletInstanceRequest,
+      headers: {
+        "x-iowallet-user-id": "x-iowallet-user-id",
+      },
+    };
+    const handler = CreateWalletInstanceHandler({
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      attestationServiceConfiguration,
+      nonceRepository,
+      walletInstanceRepository:
+        walletInstanceRepositoryThatFailsOnGetAllByUserId,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        statusCode: 500,
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+      }),
+    });
+  });
+
+  it("should return a 500 HTTP response on batchPatchWithReplaceOperation error", async () => {
+    const walletInstanceRepositoryThatFailsOnBatchPatch: WalletInstanceRepository =
+      {
+        insert: () => TE.left(new Error("not implemented")),
+        get: () => TE.left(new Error("not implemented")),
+        batchPatchWithReplaceOperation: () =>
+          TE.left(new Error("failed on batchPatch!")),
+        getAllByUserId: () => TE.left(new Error("not implemented")),
+      };
+    const req = {
+      ...H.request("https://wallet-provider.example.org"),
+      method: "POST",
+      body: walletInstanceRequest,
+      headers: {
+        "x-iowallet-user-id": "x-iowallet-user-id",
+      },
+    };
+    const handler = CreateWalletInstanceHandler({
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      attestationServiceConfiguration,
+      nonceRepository,
+      walletInstanceRepository: walletInstanceRepositoryThatFailsOnBatchPatch,
     });
 
     await expect(handler()).resolves.toEqual({

--- a/apps/io-func-wallet-solution-backend/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-func-wallet-solution-backend/src/infra/http/handlers/create-wallet-instance.ts
@@ -12,7 +12,10 @@ import { sequenceS } from "fp-ts/Apply";
 import { logErrorAndReturnResponse } from "../utils";
 
 import { requireUser } from "./utils";
-import { insertWalletInstance } from "@/wallet-instance";
+import {
+  insertWalletInstance,
+  revokeUserWalletInstancesExceptOne,
+} from "@/wallet-instance";
 import { consumeNonce } from "@/wallet-instance-request";
 
 import { validateAttestation } from "@/attestation-service";
@@ -59,6 +62,12 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
             signCount: 0,
             isRevoked: false,
           })
+        ),
+        RTE.chainW(() =>
+          revokeUserWalletInstancesExceptOne(
+            user.id,
+            walletInstanceRequest.hardwareKeyTag
+          )
         )
       )
     ),

--- a/apps/io-func-wallet-solution-backend/src/wallet-instance.ts
+++ b/apps/io-func-wallet-solution-backend/src/wallet-instance.ts
@@ -1,6 +1,8 @@
 import * as t from "io-ts";
 
-import { pipe } from "fp-ts/function";
+import * as O from "fp-ts/Option";
+import { flow, pipe } from "fp-ts/function";
+import * as RA from "fp-ts/ReadonlyArray";
 import * as TE from "fp-ts/TaskEither";
 import * as RTE from "fp-ts/ReaderTaskEither";
 
@@ -24,6 +26,17 @@ export type WalletInstanceRepository = {
     userId: WalletInstance["userId"]
   ) => TE.TaskEither<Error, WalletInstance>;
   insert: (walletInstance: WalletInstance) => TE.TaskEither<Error, void>;
+  batchPatchWithReplaceOperation: (
+    operations: Array<{
+      id: string;
+      path: string;
+      value: unknown;
+    }>,
+    userId: string
+  ) => TE.TaskEither<Error, void>;
+  getAllByUserId: (
+    userId: WalletInstance["userId"]
+  ) => TE.TaskEither<Error, WalletInstance[]>;
 };
 
 type WalletInstanceEnvironment = {
@@ -49,5 +62,34 @@ export const getValidWalletInstance: (
         walletInstance.isRevoked
           ? TE.left(new Error("The wallet instance has been revoked"))
           : TE.right(walletInstance)
+      )
+    );
+
+export const revokeUserWalletInstancesExceptOne: (
+  userId: WalletInstance["userId"],
+  walletInstanceId: WalletInstance["id"]
+) => RTE.ReaderTaskEither<WalletInstanceEnvironment, Error, void> =
+  (userId, walletInstanceId) =>
+  ({ walletInstanceRepository }) =>
+    pipe(
+      walletInstanceRepository.getAllByUserId(userId),
+      TE.map(
+        flow(
+          RA.filterMap((walletInstance) =>
+            walletInstance.id !== walletInstanceId
+              ? O.some(walletInstance.id)
+              : O.none
+          )
+        )
+      ),
+      TE.chain((walletInstancesId) =>
+        walletInstanceRepository.batchPatchWithReplaceOperation(
+          walletInstancesId.map((id) => ({
+            id,
+            path: "/isRevoked",
+            value: true,
+          })),
+          userId
+        )
       )
     );


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Added `revokeUserWalletInstancesExceptOne`  function
2. Added call to `revokeUserWalletInstancesExceptOne` in `CreateWalletInstanceHandler` after inserting a new wallet instance
3. Added `getAllByUserId` and `batchPatchWithReplaceOperation` in `WalletInstanceRepository`
4. Added unit tests

#### Motivation and Context

When adding a new wallet instance, all the previous wallet instances need to be revoked

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
