### PR TITLE
chore: Set KeyVault admins io-p-adgroup-developers

### DIFF
--- a/infra/identity/prod/README.md
+++ b/infra/identity/prod/README.md
@@ -10,7 +10,9 @@
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.97.1 |
 
 ## Modules
 
@@ -21,7 +23,13 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [azurerm_key_vault_access_policy.cd](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_key_vault_access_policy.ci](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_access_policy) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.weu-common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_resource_group.weu-common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/infra/identity/prod/data.tf
+++ b/infra/identity/prod/data.tf
@@ -1,0 +1,10 @@
+data "azurerm_client_config" "current" {}
+
+data "azurerm_resource_group" "weu-common" {
+  name = "${local.project}-rg-common"
+}
+
+data "azurerm_key_vault" "weu-common" {
+  name                = "${local.project}-kv-common"
+  resource_group_name = data.azurerm_resource_group.weu-common.name
+}

--- a/infra/identity/prod/main.tf
+++ b/infra/identity/prod/main.tf
@@ -85,3 +85,19 @@ module "app_federated_identities" {
 
   tags = local.tags
 }
+
+resource "azurerm_key_vault_access_policy" "ci" {
+  key_vault_id = data.azurerm_key_vault.weu-common.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.federated_identities.federated_ci_identity.id
+
+  secret_permissions = ["Get", "List"]
+}
+
+resource "azurerm_key_vault_access_policy" "cd" {
+  key_vault_id = data.azurerm_key_vault.weu-common.id
+  tenant_id    = data.azurerm_client_config.current.tenant_id
+  object_id    = module.federated_identities.federated_cd_identity.id
+
+  secret_permissions = ["Get", "List", "Set"]
+}

--- a/infra/resources/prod/README.md
+++ b/infra/resources/prod/README.md
@@ -31,7 +31,7 @@
 | Name | Type |
 |------|------|
 | [azurerm_resource_group.wallet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azuread_group.io_admin](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
+| [azuread_group.io_developers](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/group) | data source |
 | [azurerm_application_insights.common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/application_insights) | data source |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault.weu-common](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |

--- a/infra/resources/prod/data.tf
+++ b/infra/resources/prod/data.tf
@@ -27,8 +27,8 @@ data "azurerm_private_dns_zone" "privatelink_documents" {
   resource_group_name = data.azurerm_resource_group.weu-common.name
 }
 
-data "azuread_group" "io_admin" {
-  display_name = format("%s-%s-adgroup-admin", local.prefix, local.env_short)
+data "azuread_group" "io_developers" {
+  display_name = format("%s-%s-adgroup-developers", local.prefix, local.env_short)
 }
 
 data "azurerm_application_insights" "common" {

--- a/infra/resources/prod/main.tf
+++ b/infra/resources/prod/main.tf
@@ -116,7 +116,7 @@ module "iam" {
 
   key_vault = {
     id        = module.key_vaults.key_vault_wallet.id
-    admin_ids = [data.azuread_group.io_admin.object_id]
+    admin_ids = [data.azuread_group.io_developers.object_id]
   }
 
   cdn_storage_account_id = module.cdn.storage_account_cdn.id


### PR DESCRIPTION
Co-authored-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>

<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Set `io-p-adgroup-developers` as KeyVault admin

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

All team members require access to keyvault

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
