### PR TITLE
feat: [SIW-1204] Updated createWalletAttestation error status codes

### DIFF
--- a/apps/io-wallet-user-func/openapi.yaml
+++ b/apps/io-wallet-user-func/openapi.yaml
@@ -89,6 +89,12 @@ paths:
             application/jwt:
               schema:
                 $ref: "#/components/schemas/WalletAttestationView"
+        "403":
+          description: The wallet instance was revoked
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: The wallet instance was not found
+          $ref: "#/components/responses/NotFound"
         "422":
           $ref: "#/components/responses/UnprocessableContent"
         "500":
@@ -119,6 +125,20 @@ components:
       in: header
 
   responses:
+    Forbidden:
+      description: the server understands the request but refuses to authorize it
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
+    NotFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ProblemDetail"
+
     UnprocessableContent:
       description: Unprocessable Content
       content:

--- a/apps/io-wallet-user-func/openapi.yaml
+++ b/apps/io-wallet-user-func/openapi.yaml
@@ -126,7 +126,7 @@ components:
 
   responses:
     Forbidden:
-      description: the server understands the request but refuses to authorize it
+      description: The server understands the request but refuses to authorize it
       content:
         application/json:
           schema:

--- a/apps/io-wallet-user-func/src/infra/http/utils.ts
+++ b/apps/io-wallet-user-func/src/infra/http/utils.ts
@@ -5,6 +5,10 @@ import * as RTE from "fp-ts/ReaderTaskEither";
 
 import { flow } from "fp-ts/function";
 
+export class EntityNotFoundError extends Error {
+  name = "EntityNotFoundError";
+}
+
 // Encode domain errors to http errors
 const toHttpError = (e: Error): Error => {
   if (e.name === "HttpError") {
@@ -13,14 +17,10 @@ const toHttpError = (e: Error): Error => {
   switch (e.name) {
     case "EntityNotFoundError":
       return new H.HttpNotFoundError(e.message);
-    case "ActionNotAllowedError":
-      return new H.HttpBadRequestError(e.message);
-    case "InvalidExpireDateError":
-      return new H.HttpBadRequestError(e.message);
-    case "TooManyRequestsError":
-      return new H.HttpTooManyRequestsError(e.message);
     case "HealthCheckError":
       return new H.HttpError(e.message);
+    case "WalletInstanceRevoked":
+      return new H.HttpForbiddenError(e.message);
   }
   return e;
 };


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Added `403` and `404` HTTP status codes to `createWalletAttestation` function handler
2. Updated unit tests
3. Updated openapi

#### Motivation and Context

Now `403` is returned when the wallet instance is revoked and `404` when the wallet instance is not found. The client needs to get this information

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
