### PR TITLE
fix: [SIW-1206] Update getUserByFiscalCode function

### DIFF
--- a/.changeset/wild-lions-brake.md
+++ b/.changeset/wild-lions-brake.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-user-func": patch
+---
+
+Update

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-user-by-fiscal-code.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-user-by-fiscal-code.spec.ts
@@ -8,7 +8,8 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
 describe("GetUserByFiscalCodeHandler", () => {
   const userRepository: UserRepository = {
-    getUserByFiscalCode: () => TE.right({ id: "pdv_id" as NonEmptyString }),
+    getOrCreateUserByFiscalCode: () =>
+      TE.right({ id: "pdv_id" as NonEmptyString }),
     getFiscalCodeByUserId: () => TE.left(new Error("not implemented")),
   };
 
@@ -73,7 +74,7 @@ describe("GetUserByFiscalCodeHandler", () => {
 
   it("should return a 500 HTTP response when getUserByFiscalCode returns error", async () => {
     const userRepositoryThatFailsOnGetUserByFiscalCode: UserRepository = {
-      getUserByFiscalCode: () =>
+      getOrCreateUserByFiscalCode: () =>
         TE.left(new Error("failed on getIdByFiscalCode!")),
       getFiscalCodeByUserId: () => TE.left(new Error("not implemented")),
     };

--- a/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
+++ b/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
@@ -39,11 +39,11 @@ export class PdvTokenizerClient
       TE.tryCatch(
         async () => {
           const result = await fetch(
-            new URL("/tokenizer/v1/tokens/search", this.#baseURL),
+            new URL("/tokenizer/v1/tokens", this.#baseURL),
             {
               ...this.#options,
               signal: AbortSignal.timeout(3000),
-              method: "POST",
+              method: "PUT",
               body: JSON.stringify({
                 pii: fiscalCode,
               }),

--- a/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
+++ b/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
@@ -38,6 +38,7 @@ export class PdvTokenizerClient
     pipe(
       TE.tryCatch(
         async () => {
+          this.setHeaders({ "Content-Type": "application/json" });
           const result = await fetch(
             new URL("/tokenizer/v1/tokens", this.#baseURL),
             {
@@ -117,5 +118,12 @@ export class PdvTokenizerClient
       signal: AbortSignal.timeout(3000),
       method: "GET",
     });
+  }
+
+  setHeaders(headers: object) {
+    this.#options.headers = {
+      ...this.#options.headers,
+      ...headers,
+    };
   }
 }

--- a/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
+++ b/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
@@ -34,7 +34,7 @@ export class PdvTokenizerClient
     this.#testUUID = testUUID;
   }
 
-  getUserByFiscalCode = (fiscalCode: FiscalCode) =>
+  getOrCreateUserByFiscalCode = (fiscalCode: FiscalCode) =>
     pipe(
       TE.tryCatch(
         async () => {

--- a/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
+++ b/apps/io-wallet-user-func/src/infra/pdv-tokenizer/client.ts
@@ -38,11 +38,14 @@ export class PdvTokenizerClient
     pipe(
       TE.tryCatch(
         async () => {
-          this.setHeaders({ "Content-Type": "application/json" });
+          const headers = {
+            ...this.#options.headers,
+            "Content-Type": "application/json",
+          };
           const result = await fetch(
             new URL("/tokenizer/v1/tokens", this.#baseURL),
             {
-              ...this.#options,
+              headers,
               signal: AbortSignal.timeout(3000),
               method: "PUT",
               body: JSON.stringify({
@@ -118,12 +121,5 @@ export class PdvTokenizerClient
       signal: AbortSignal.timeout(3000),
       method: "GET",
     });
-  }
-
-  setHeaders(headers: object) {
-    this.#options.headers = {
-      ...this.#options.headers,
-      ...headers,
-    };
   }
 }

--- a/apps/io-wallet-user-func/src/user.ts
+++ b/apps/io-wallet-user-func/src/user.ts
@@ -10,7 +10,9 @@ export const User = t.type({
 export type User = t.TypeOf<typeof User>;
 
 export type UserRepository = {
-  getUserByFiscalCode: (fiscalCode: FiscalCode) => TE.TaskEither<Error, User>;
+  getOrCreateUserByFiscalCode: (
+    fiscalCode: FiscalCode
+  ) => TE.TaskEither<Error, User>;
   getFiscalCodeByUserId: (
     id: string
   ) => TE.TaskEither<Error, { fiscalCode: FiscalCode }>;
@@ -25,4 +27,4 @@ export const getUserByFiscalCode: (
 ) => RTE.ReaderTaskEither<UserEnvironment, Error, User> =
   (fiscalCode) =>
   ({ userRepository }) =>
-    userRepository.getUserByFiscalCode(fiscalCode);
+    userRepository.getOrCreateUserByFiscalCode(fiscalCode);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

Updated `getUserByFiscalCode` method in `PdvTokenizerClient` class and `UserRepository` type in `getOrCreateUserByFiscalCode`

#### Motivation and Context

The previous implementation of the `getUserByFiscalCode` method called an endpoint of PDV tokenizer that returns the id associated with a fiscal code. Now the `getOrCreateUserByFiscalCode` method calls an endpoint of PDV tokenizer that creates the id associated with a fiscal code in case it does not exist yet

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
