### PR TITLE
chore: [SIW-1263] Updated createWalletInstance function

### DIFF
--- a/.changeset/violet-coins-check.md
+++ b/.changeset/violet-coins-check.md
@@ -1,0 +1,6 @@
+---
+"io-wallet-common": patch
+"io-wallet-user-func": patch
+---
+
+Patch

--- a/apps/io-wallet-user-func/local.settings.json.example
+++ b/apps/io-wallet-user-func/local.settings.json.example
@@ -30,6 +30,7 @@
     "PdvTokenizerApiKey": "PDV_TOKENIZER_API_KEY",
     "PdvTokenizerTestUUID": "PDV_TOKENIZER_TEST_UUID",
     "EntityConfigurationStorageAccount__serviceUri": "ENTITY_CONFIGURATION_STORAGE_ACCOUNT_SERVICE_URI"
-    "EntityConfigurationStorageContainerName": "ENTITY_CONFIGURATION_STORAGE_CONTAINER_NAME"
+    "EntityConfigurationStorageContainerName": "ENTITY_CONFIGURATION_STORAGE_CONTAINER_NAME",
+    "WalletInstancesStorageQueueServiceUrl: "WALLET_INSTANCES_STORAGE_QUEUE_SERVICE_URL"
   }
 }

--- a/apps/io-wallet-user-func/package.json
+++ b/apps/io-wallet-user-func/package.json
@@ -17,6 +17,7 @@
     "@azure/cosmos": "^4.0.0",
     "@azure/functions": "^4.4.0",
     "@azure/identity": "^4.3.0",
+    "@azure/storage-queue": "^12.22.0",
     "@pagopa/handler-kit": "^1.1.0",
     "@pagopa/handler-kit-azure-func": "^2.0.7",
     "@pagopa/ts-commons": "^13.1.1",

--- a/apps/io-wallet-user-func/src/app/config.ts
+++ b/apps/io-wallet-user-func/src/app/config.ts
@@ -58,7 +58,12 @@ const AzureConfiguration = t.type({
     dbName: t.string,
     endpoint: t.string,
   }),
-  storage: t.type({ entityConfigurationContainerName: t.string }),
+  storage: t.type({
+    entityConfiguration: t.type({ containerName: t.string }),
+    walletInstances: t.type({
+      queueServiceUrl: t.string,
+    }),
+  }),
 });
 
 type AzureConfiguration = t.TypeOf<typeof AzureConfiguration>;
@@ -221,20 +226,28 @@ export const getAzureConfigFromEnvironment: RE.ReaderEither<
     entityConfigurationStorageContainerName: readFromEnvironment(
       "EntityConfigurationStorageContainerName",
     ),
+    walletInstancesStorageQueueServiceUrl: readFromEnvironment(
+      "WalletInstancesStorageQueueServiceUrl",
+    ),
   }),
   RE.map(
     ({
       cosmosDbDatabaseName,
       cosmosDbEndpoint,
       entityConfigurationStorageContainerName,
+      walletInstancesStorageQueueServiceUrl,
     }) => ({
       cosmos: {
         dbName: cosmosDbDatabaseName,
         endpoint: cosmosDbEndpoint,
       },
       storage: {
-        entityConfigurationContainerName:
-          entityConfigurationStorageContainerName,
+        entityConfiguration: {
+          containerName: entityConfigurationStorageContainerName,
+        },
+        walletInstances: {
+          queueServiceUrl: walletInstancesStorageQueueServiceUrl,
+        },
       },
     }),
   ),

--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -47,7 +47,7 @@ const pdvTokenizerClient = new PdvTokenizerClient(config.pdvTokenizer);
 const walletInstanceRepository = new CosmosDbWalletInstanceRepository(database);
 
 const queueServiceClient = new QueueServiceClient(
-  `https://ioditnwallet.queue.core.windows.net`,
+  config.azure.storage.walletInstances.queueServiceUrl,
   credential,
 );
 
@@ -111,7 +111,7 @@ app.timer("generateEntityConfiguration", {
   }),
   return: output.storageBlob({
     connection: "EntityConfigurationStorageAccount",
-    path: `${config.azure.storage.entityConfigurationContainerName}/openid-federation`,
+    path: `${config.azure.storage.entityConfiguration.containerName}/openid-federation`,
   }),
   schedule: "0 0 */12 * * *", // the function returns a jwt that is valid for 24 hours, so the trigger is set every 12 hours
 });

--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -57,7 +57,11 @@ const onWalletInstanceCreatedQueueClient = queueServiceClient.getQueueClient(
 
 app.http("healthCheck", {
   authLevel: "anonymous",
-  handler: HealthFunction({ cosmosClient, pdvTokenizerClient }),
+  handler: HealthFunction({
+    cosmosClient,
+    pdvTokenizerClient,
+    queueClient: onWalletInstanceCreatedQueueClient,
+  }),
   methods: ["GET"],
   route: "health",
 });

--- a/apps/io-wallet-user-func/src/infra/azure/cosmos/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/azure/cosmos/wallet-instance.ts
@@ -15,28 +15,25 @@ export class CosmosDbWalletInstanceRepository
     this.#container = db.container("wallet-instances");
   }
 
-  batchPatchWithReplaceOperation(
+  batchPatch(
     operationsInput: {
       id: string;
-      path: string;
-      value: unknown;
+      operations: {
+        op: "add" | "incr" | "remove" | "replace" | "set";
+        path: string;
+        value: unknown;
+      }[];
     }[],
     userId: string,
   ) {
     return TE.tryCatch(
       async () => {
         const operations: PatchOperationInput[] = operationsInput.map(
-          ({ id, path, value }) => ({
+          ({ id, operations }) => ({
             id,
             operationType: "Patch",
             resourceBody: {
-              operations: [
-                {
-                  op: "replace",
-                  path,
-                  value,
-                },
-              ],
+              operations,
             },
           }),
         );

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
@@ -64,10 +64,11 @@ const attestationServiceConfiguration = {
 };
 
 const walletInstanceRepository: WalletInstanceRepository = {
-  batchPatchWithReplaceOperation: () => TE.left(new Error("not implemented")),
+  batchPatch: () => TE.left(new Error("not implemented")),
   get: () =>
     TE.right(
       O.some({
+        createdAt: new Date(),
         hardwareKey,
         id: "123" as NonEmptyString,
         isRevoked: false,
@@ -187,14 +188,15 @@ describe("CreateWalletAttestationHandler", async () => {
 
   it("should return a 403 HTTP response when the wallet instance is revoked", async () => {
     const walletInstanceRepositoryWithRevokedWI: WalletInstanceRepository = {
-      batchPatchWithReplaceOperation: () =>
-        TE.left(new Error("not implemented")),
+      batchPatch: () => TE.left(new Error("not implemented")),
       get: () =>
         TE.right(
           O.some({
+            createdAt: new Date(),
             hardwareKey,
             id: "123" as NonEmptyString,
             isRevoked: true,
+            revokedAt: new Date(),
             signCount: 0,
             userId: "123" as NonEmptyString,
           }),
@@ -242,8 +244,7 @@ describe("CreateWalletAttestationHandler", async () => {
 
   it("should return a 404 HTTP response when the wallet instance is not found", async () => {
     const walletInstanceRepositoryWithNotFoundWI: WalletInstanceRepository = {
-      batchPatchWithReplaceOperation: () =>
-        TE.left(new Error("not implemented")),
+      batchPatch: () => TE.left(new Error("not implemented")),
       get: () => TE.right(O.none),
       getAllByUserId: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
@@ -30,7 +30,7 @@ describe("CreateWalletInstanceHandler", () => {
   };
 
   const walletInstanceRepository: WalletInstanceRepository = {
-    batchPatchWithReplaceOperation: () => TE.right(undefined),
+    batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.right([]),
     insert: () => TE.right(undefined),
@@ -205,8 +205,7 @@ describe("CreateWalletInstanceHandler", () => {
   it("should return a 500 HTTP response on insertWalletInstance error", async () => {
     const walletInstanceRepositoryThatFailsOnInsert: WalletInstanceRepository =
       {
-        batchPatchWithReplaceOperation: () =>
-          TE.left(new Error("not implemented")),
+        batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("failed on insert!")),
@@ -242,8 +241,7 @@ describe("CreateWalletInstanceHandler", () => {
   it("should return a 500 HTTP response on getAllByUserId error", async () => {
     const walletInstanceRepositoryThatFailsOnGetAllByUserId: WalletInstanceRepository =
       {
-        batchPatchWithReplaceOperation: () =>
-          TE.left(new Error("not implemented")),
+        batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("failed on getAllByUserId!")),
         insert: () => TE.left(new Error("not implemented")),
@@ -277,11 +275,10 @@ describe("CreateWalletInstanceHandler", () => {
     });
   });
 
-  it("should return a 500 HTTP response on batchPatchWithReplaceOperation error", async () => {
+  it("should return a 500 HTTP response on batchPatch error", async () => {
     const walletInstanceRepositoryThatFailsOnBatchPatch: WalletInstanceRepository =
       {
-        batchPatchWithReplaceOperation: () =>
-          TE.left(new Error("failed on batchPatch!")),
+        batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -69,7 +69,6 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
                 walletInstanceRequest.hardwareKeyTag,
               ),
             ),
-            // enqueue si prende tutto?
             RTE.chainW(() => enqueue(walletInstance)),
           ),
         ),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -51,6 +51,7 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
         RTE.chainW(() => validateAttestation(walletInstanceRequest)),
         RTE.chainW(({ hardwareKey }) =>
           insertWalletInstance({
+            createdAt: new Date(), // side effect
             hardwareKey,
             id: walletInstanceRequest.hardwareKeyTag,
             isRevoked: false,

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -52,10 +52,10 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
         RTE.chainW(() => validateAttestation(walletInstanceRequest)),
         RTE.bind("walletInstance", ({ hardwareKey }) =>
           RTE.right({
-            createdAt: new Date(), // side effect
+            createdAt: new Date(),
             hardwareKey,
             id: walletInstanceRequest.hardwareKeyTag,
-            isRevoked: false as false,
+            isRevoked: false as const,
             signCount: 0,
             userId: user.id,
           }),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -12,6 +12,7 @@ import * as E from "fp-ts/lib/Either";
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as t from "io-ts";
 import { logErrorAndReturnResponse } from "io-wallet-common/http-response";
+import { enqueue } from "io-wallet-common/storage-queue";
 
 import { requireUser } from "./utils";
 
@@ -49,20 +50,27 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
       pipe(
         consumeNonce(walletInstanceRequest.challenge),
         RTE.chainW(() => validateAttestation(walletInstanceRequest)),
-        RTE.chainW(({ hardwareKey }) =>
-          insertWalletInstance({
+        RTE.bind("walletInstance", ({ hardwareKey }) =>
+          RTE.right({
             createdAt: new Date(), // side effect
             hardwareKey,
             id: walletInstanceRequest.hardwareKeyTag,
-            isRevoked: false,
+            isRevoked: false as false,
             signCount: 0,
             userId: user.id,
           }),
         ),
-        RTE.chainW(() =>
-          revokeUserWalletInstancesExceptOne(
-            user.id,
-            walletInstanceRequest.hardwareKeyTag,
+        RTE.chainW(({ walletInstance }) =>
+          pipe(
+            insertWalletInstance(walletInstance),
+            RTE.chainW(() =>
+              revokeUserWalletInstancesExceptOne(
+                user.id,
+                walletInstanceRequest.hardwareKeyTag,
+              ),
+            ),
+            // enqueue si prende tutto?
+            RTE.chainW(() => enqueue(walletInstance)),
           ),
         ),
       ),

--- a/apps/io-wallet-web-func/src/infra/http/handlers/health.ts
+++ b/apps/io-wallet-web-func/src/infra/http/handlers/health.ts
@@ -6,7 +6,7 @@ import { constVoid, pipe } from "fp-ts/function";
 import {
   HealthCheckError,
   getCosmosHealth,
-} from "io-wallet-common/cosmos-health-check";
+} from "io-wallet-common/azure-health-check";
 import { logErrorAndReturnResponse } from "io-wallet-common/http-response";
 
 const getHealthCheck: RTE.ReaderTaskEither<

--- a/packages/io-wallet-common/package.json
+++ b/packages/io-wallet-common/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^4.0.0",
+    "@azure/storage-queue": "^12.22.0",
     "@pagopa/handler-kit": "^1.1.0",
     "@pagopa/logger": "^1.0.1",
     "@pagopa/ts-commons": "^13.1.1",

--- a/packages/io-wallet-common/src/azure-health-check.ts
+++ b/packages/io-wallet-common/src/azure-health-check.ts
@@ -37,6 +37,6 @@ export const getStorageQueueHealth: RTE.ReaderTaskEither<
       () => new Error("storage-queue-error"),
     ),
     TE.chain((exists) =>
-      exists ? TE.right(true) : TE.left(new Error("storage-queue-error")),
+      exists ? TE.right(true) : TE.left(new Error("storage-queue-not-found")),
     ),
   );

--- a/packages/io-wallet-common/src/azure-health-check.ts
+++ b/packages/io-wallet-common/src/azure-health-check.ts
@@ -1,4 +1,5 @@
 import { CosmosClient } from "@azure/cosmos";
+import { QueueClient } from "@azure/storage-queue";
 import { pipe } from "fp-ts/function";
 import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -21,4 +22,21 @@ export const getCosmosHealth: RTE.ReaderTaskEither<
       () => new Error("cosmos-db-error"),
     ),
     TE.map(() => true),
+  );
+
+export const getStorageQueueHealth: RTE.ReaderTaskEither<
+  {
+    queueClient: QueueClient;
+  },
+  Error,
+  true
+> = ({ queueClient }) =>
+  pipe(
+    TE.tryCatch(
+      () => queueClient.exists(),
+      () => new Error("storage-queue-error"),
+    ),
+    TE.chain((exists) =>
+      exists ? TE.right(true) : TE.left(new Error("storage-queue-error")),
+    ),
   );

--- a/packages/io-wallet-common/src/storage-queue.ts
+++ b/packages/io-wallet-common/src/storage-queue.ts
@@ -16,7 +16,6 @@ class StorageQueueError extends Error {
 
 const toBase64 = flow(Buffer.from, (b) => b.toString("base64"));
 
-// vedere il fatto che torna l'id
 const sendMessage =
   (
     message: string,

--- a/packages/io-wallet-common/src/storage-queue.ts
+++ b/packages/io-wallet-common/src/storage-queue.ts
@@ -1,0 +1,44 @@
+import { QueueClient } from "@azure/storage-queue";
+import * as E from "fp-ts/lib/Either";
+import { stringify } from "fp-ts/lib/Json";
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import * as TE from "fp-ts/lib/TaskEither";
+import { flow, pipe } from "fp-ts/lib/function";
+
+class StorageQueueError extends Error {
+  errorCode?: string;
+  name = "StorageQueueError";
+  constructor(errorCode?: string) {
+    super("Unable to enqueue the message.");
+    this.errorCode = errorCode;
+  }
+}
+
+const toBase64 = flow(Buffer.from, (b) => b.toString("base64"));
+
+// vedere il fatto che torna l'id
+const sendMessage =
+  (
+    message: string,
+  ): RTE.ReaderTaskEither<
+    { queueClient: QueueClient },
+    StorageQueueError,
+    string
+  > =>
+  ({ queueClient }) =>
+    pipe(
+      TE.tryCatch(() => queueClient.sendMessage(message), E.toError),
+      TE.filterOrElse(
+        (response) => response.errorCode === undefined,
+        (response) => new StorageQueueError(response.errorCode),
+      ),
+      TE.map(({ messageId }) => messageId),
+    );
+
+export const enqueue = flow(
+  stringify,
+  E.mapLeft(() => new Error("Unable to serialize the message.")),
+  E.map(toBase64),
+  RTE.fromEither,
+  RTE.chainW(sendMessage),
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,7 +51,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-client@npm:^1.9.2":
+"@azure/core-client@npm:^1.3.0, @azure/core-client@npm:^1.6.2, @azure/core-client@npm:^1.9.2":
   version: 1.9.2
   resolution: "@azure/core-client@npm:1.9.2"
   dependencies:
@@ -63,6 +63,26 @@ __metadata:
     "@azure/logger": ^1.0.0
     tslib: ^2.6.2
   checksum: 961b829dfda4f734a763e9480a2ea622a7031ba2da4126d0add6e351a9f73ddc5782bf2b766735d976b61da3857014e0a90223d1f85d1c68468747a7a56851c3
+  languageName: node
+  linkType: hard
+
+"@azure/core-http-compat@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "@azure/core-http-compat@npm:2.1.2"
+  dependencies:
+    "@azure/abort-controller": ^2.0.0
+    "@azure/core-client": ^1.3.0
+    "@azure/core-rest-pipeline": ^1.3.0
+  checksum: 387d0187607d95a6876f63d4b689210bce6ad243f48e56413136ba3875a8a9c4e238813307fb0cf0c53298f4b9d0893d04321c9331812bc74cf0f4e3e6872069
+  languageName: node
+  linkType: hard
+
+"@azure/core-paging@npm:^1.1.1":
+  version: 1.6.2
+  resolution: "@azure/core-paging@npm:1.6.2"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: 4b57f953998473ee784c3ea774a8b54f4be0ec239bd43cbabe28113ca18f141455289713302d4fcd802898dd7ab58380ff575b7ce9400ec1ec20c505791c0b25
   languageName: node
   linkType: hard
 
@@ -84,7 +104,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@azure/core-rest-pipeline@npm:^1.1.0, @azure/core-rest-pipeline@npm:^1.9.1":
+"@azure/core-rest-pipeline@npm:^1.1.0, @azure/core-rest-pipeline@npm:^1.10.1, @azure/core-rest-pipeline@npm:^1.3.0, @azure/core-rest-pipeline@npm:^1.9.1":
   version: 1.16.0
   resolution: "@azure/core-rest-pipeline@npm:1.16.0"
   dependencies:
@@ -142,6 +162,16 @@ __metadata:
     "@azure/abort-controller": ^2.0.0
     tslib: ^2.6.2
   checksum: 9246dc5bd246e7b94883ea8130fce04e2f22abd1e94afcff7a3e92a4c2da5e9b382dbf89a606b21d70bc8b01c7c89c84e803ca9da27f78d87f72bdff91ec7380
+  languageName: node
+  linkType: hard
+
+"@azure/core-xml@npm:^1.3.2":
+  version: 1.4.2
+  resolution: "@azure/core-xml@npm:1.4.2"
+  dependencies:
+    fast-xml-parser: ^4.3.2
+    tslib: ^2.6.2
+  checksum: f3815db55f0280db6080a3fc5b6187ad45cacf5c3842ea806a5565886edf2ebf2fa9fc1175407cf58d462341962a8396513943543b332b37b313ac3a79dc28fa
   languageName: node
   linkType: hard
 
@@ -253,6 +283,25 @@ __metadata:
     "@opentelemetry/instrumentation": ^0.41.2
     tslib: ^2.2.0
   checksum: ff7c4b885536d8ce46787b0c1995a4241c86f46dd8869eebb3ba843148ddea9761f229a8415ff4a57bd481c02855b510c8c0af01a96ca3539f12e63ac7acd53a
+  languageName: node
+  linkType: hard
+
+"@azure/storage-queue@npm:^12.22.0":
+  version: 12.22.0
+  resolution: "@azure/storage-queue@npm:12.22.0"
+  dependencies:
+    "@azure/abort-controller": ^1.0.0
+    "@azure/core-auth": ^1.4.0
+    "@azure/core-client": ^1.6.2
+    "@azure/core-http-compat": ^2.0.0
+    "@azure/core-paging": ^1.1.1
+    "@azure/core-rest-pipeline": ^1.10.1
+    "@azure/core-tracing": ^1.0.0
+    "@azure/core-util": ^1.6.1
+    "@azure/core-xml": ^1.3.2
+    "@azure/logger": ^1.0.0
+    tslib: ^2.2.0
+  checksum: e96e62aa9ef6f24039336356dd8b84bf0c4215d57d91b459c9c6b40c2249697a9ce8301b2e3083b4f9f8e66359cd7d0dfd47f8fb8f5f7dbda4a23c4dedd3a607
   languageName: node
   linkType: hard
 
@@ -3777,6 +3826,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-xml-parser@npm:^4.3.2":
+  version: 4.4.0
+  resolution: "fast-xml-parser@npm:4.4.0"
+  dependencies:
+    strnum: ^1.0.5
+  bin:
+    fxparser: src/cli/cli.js
+  checksum: ad33a4b5165a0ffcb6e17ae78825bd4619a8298844a8a8408f2ea141a0d2d9439d18865dc5254162f09fe54d510ff18e5d5c0a190869cab21fc745ee66be816b
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.17.1
   resolution: "fastq@npm:1.17.1"
@@ -4522,6 +4582,7 @@ __metadata:
   resolution: "io-wallet-common@workspace:packages/io-wallet-common"
   dependencies:
     "@azure/cosmos": ^4.0.0
+    "@azure/storage-queue": ^12.22.0
     "@pagopa/eslint-config": ^4.0.1
     "@pagopa/handler-kit": ^1.1.0
     "@pagopa/logger": ^1.0.1
@@ -4543,6 +4604,7 @@ __metadata:
     "@azure/cosmos": ^4.0.0
     "@azure/functions": ^4.4.0
     "@azure/identity": ^4.3.0
+    "@azure/storage-queue": ^12.22.0
     "@pagopa/eslint-config": ^4.0.1
     "@pagopa/handler-kit": ^1.1.0
     "@pagopa/handler-kit-azure-func": ^2.0.7
@@ -7030,6 +7092,13 @@ __metadata:
   dependencies:
     js-tokens: ^9.0.0
   checksum: 37c2072634d2de11a3644fe1bcf4abd566d85e89f0d8e8b10d35d04e7bef962e7c112fbe5b805ce63e59dfacedc240356eeef57976351502966b7c64b742c6ac
+  languageName: node
+  linkType: hard
+
+"strnum@npm:^1.0.5":
+  version: 1.0.5
+  resolution: "strnum@npm:1.0.5"
+  checksum: 651b2031db5da1bf4a77fdd2f116a8ac8055157c5420f5569f64879133825915ad461513e7202a16d7fec63c54fd822410d0962f8ca12385c4334891b9ae6dd2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Updated `createWalletInstance` function with unit tests
2. Added `WalletInstanceValid` and `WalletInstanceRevoked` as in `io-wallet-web-func`
3. Added function to send message to a queue in `io-wallet-common`
4. Updated `health` function with storage queue health check

#### Motivation and Context

Now the function `createWalletInstance` adds the `createdAt` field when inserting a new wallet instance into the database and adds the `revokedAt` field when revoking one.
Then, after creating the wallet instance, it sends the message containing the wallet instance to the `on-wallet-instance-created` queue so that the `web` database can be updated with the new document as well

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
