### PR TITLE
[EC-335] Add rule engine on CDN to expose ".well-known" path

### DIFF
--- a/infra/resources/_modules/cdn/cdn.tf
+++ b/infra/resources/_modules/cdn/cdn.tf
@@ -32,13 +32,13 @@ resource "azurerm_cdn_endpoint" "this" {
     request_uri_condition {
       operator = "BeginsWith"
       match_values = [
-        "https://wallet.io.pagopa.it/.well-known/"
+        "https://${local.dns_name}.${local.cdn_dns_zone_name}/.well-known/"
       ]
     }
 
     url_rewrite_action {
       source_pattern          = "/.well-known/"
-      destination             = "/assets/"
+      destination             = "/well-known/"
       preserve_unmatched_path = true
     }
   }

--- a/infra/resources/_modules/cdn/cdn.tf
+++ b/infra/resources/_modules/cdn/cdn.tf
@@ -26,8 +26,26 @@ resource "azurerm_cdn_endpoint" "this" {
   }
 
   delivery_rule {
-    name  = "EnforceHTTPS"
+    name  = "WellKnownRewrite"
     order = 1
+
+    request_uri_condition {
+      operator = "BeginsWith"
+      match_values = [
+        "https://wallet.io.pagopa.it/.well-known/"
+      ]
+    }
+
+    url_rewrite_action {
+      source_pattern          = "/.well-known/"
+      destination             = "/assets/"
+      preserve_unmatched_path = true
+    }
+  }
+
+  delivery_rule {
+    name  = "EnforceHTTPS"
+    order = 2
 
     request_scheme_condition {
       operator     = "Equal"

--- a/infra/resources/_modules/cdn/cdn.tf
+++ b/infra/resources/_modules/cdn/cdn.tf
@@ -32,7 +32,7 @@ resource "azurerm_cdn_endpoint" "this" {
     request_uri_condition {
       operator = "BeginsWith"
       match_values = [
-        "https://${local.dns_name}.${local.cdn_dns_zone_name}/.well-known/"
+        "https://${local.cdn_hostname}/.well-known/"
       ]
     }
 

--- a/infra/resources/_modules/cdn/dns.tf
+++ b/infra/resources/_modules/cdn/dns.tf
@@ -1,5 +1,5 @@
 resource "azurerm_dns_cname_record" "this" {
-  name                = "wallet"
+  name                = local.dns_name
   zone_name           = local.cdn_dns_zone_name
   resource_group_name = local.dns_zone_name_resource_group_name
   ttl                 = 3600

--- a/infra/resources/_modules/cdn/locals.tf
+++ b/infra/resources/_modules/cdn/locals.tf
@@ -1,5 +1,7 @@
 locals {
   dns_zone_name_resource_group_name = "io-p-rg-external"
-  cdn_dns_zone_name                 = "io.pagopa.it"
-  cdn_hostname                      = "wallet.${local.cdn_dns_zone_name}"
+
+  dns_name          = "wallet"
+  cdn_dns_zone_name = "io.pagopa.it"
+  cdn_hostname      = "wallet.${local.cdn_dns_zone_name}"
 }

--- a/infra/resources/_modules/cdn/locals.tf
+++ b/infra/resources/_modules/cdn/locals.tf
@@ -3,5 +3,5 @@ locals {
 
   dns_name          = "wallet"
   cdn_dns_zone_name = "io.pagopa.it"
-  cdn_hostname      = "wallet.${local.cdn_dns_zone_name}"
+  cdn_hostname      = "${local.dns_name}.${local.cdn_dns_zone_name}"
 }

--- a/infra/resources/_modules/cdn/storage_account.tf
+++ b/infra/resources/_modules/cdn/storage_account.tf
@@ -22,3 +22,11 @@ resource "azurerm_storage_account" "this" {
 
   tags = var.tags
 }
+
+resource "azurerm_storage_container" "well_known" {
+  name                 = "well-known"
+  storage_account_name = azurerm_storage_account.this.name
+
+  # tfsec:ignore:azure-storage-no-public-access
+  container_access_type = "container"
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Add rule engine on CDN to expose ".well-known" path

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Storage Accounts can't have container starting with `.` symbol. To workaround this issue, this PR introduces a URL rewrite on CDN site to remove the `.well-known` segment from URL path and replace it with a more generic `assets`.
Returned status code is still 200 and there is no redirect shown to users as it happens on CDN pop nodes.

HTTPS is still enforced

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
