### PR TITLE
[SIW-1371 ] Fix role assignment for Function App User staging

### DIFF
--- a/infra/resources/_modules/iam/key_vault_iam.tf
+++ b/infra/resources/_modules/iam/key_vault_iam.tf
@@ -13,7 +13,7 @@ resource "azurerm_role_assignment" "func_app_user_to_kv_secrets" {
 }
 
 resource "azurerm_role_assignment" "func_app_user_staging_slot_to_kv_secrets" {
-  for_each = var.function_app.staging_principal_id == null ? [] : toset([])
+  count = var.function_app.staging_principal_id != null ? 1 : 0
 
   role_definition_name = "Key Vault Secrets User"
   scope                = var.key_vault.id


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
Changing the method to check whether to create the `azurerm_role_assignment.func_app_user_staging_slot_to_kv_secrets` resource

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
With the current check we see if the `principal id` of the staging is `null`, but then in both cases we will have an empty list on which to cycle, with this fix we use the `count` that is most suitable for a check without cycle, and if is different from `null` then the resource will be created otherwise not.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
