### PR TITLE
feat: Add DeviceDetails field on Wallet Instance

### DIFF
--- a/apps/io-wallet-user-func/src/attestation-service.ts
+++ b/apps/io-wallet-user-func/src/attestation-service.ts
@@ -2,9 +2,12 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as RTE from "fp-ts/ReaderTaskEither";
 import * as TE from "fp-ts/TaskEither";
 import { pipe } from "fp-ts/function";
+import * as t from "io-ts";
 
 import { AttestationServiceConfiguration } from "./app/config";
 import { MobileAttestationService } from "./infra/attestation-service";
+import { AndroidDeviceDetails } from "./infra/attestation-service/android";
+import { IosDeviceDetails } from "./infra/attestation-service/ios";
 import { JwkPublicKey } from "./jwk";
 import { WalletAttestationRequest } from "./wallet-attestation-request";
 import { WalletInstanceRequest } from "./wallet-instance-request";
@@ -14,7 +17,11 @@ export enum OperatingSystem {
   iOS = "Apple iOS",
 }
 
+export const DeviceDetails = t.union([AndroidDeviceDetails, IosDeviceDetails]);
+export type DeviceDetails = t.TypeOf<typeof DeviceDetails>;
+
 export interface ValidatedAttestation {
+  deviceDetails: DeviceDetails;
   hardwareKey: JwkPublicKey;
 }
 

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/__test__/attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/__test__/attestation.spec.ts
@@ -29,6 +29,19 @@ describe("AndroidAttestationValidation", () => {
       x509Chain,
     });
     const expectedResult = {
+      deviceDetails: {
+        attestationSecurityLevel: 2,
+        attestationVersion: 4,
+        bootPatchLevel: "20230805",
+        deviceLocked: true,
+        keymasterSecurityLevel: 2,
+        keymasterVersion: 41,
+        osPatchLevel: 202308,
+        osVersion: 130000,
+        platform: "android",
+        vendorPatchLevel: "20230805",
+        verifiedBootState: 0,
+      },
       hardwareKey,
     };
 

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/attestation.ts
@@ -8,6 +8,19 @@ import { X509Certificate, createPublicKey } from "crypto";
 import * as jose from "jose";
 import * as pkijs from "pkijs";
 
+import { AndroidDeviceDetails } from ".";
+
+class AndroidAttestationError extends Error {
+  name = "AndroidAttestationError";
+  constructor(message: string, deviceDetails?: AndroidDeviceDetails) {
+    super(
+      deviceDetails
+        ? `[Android Attestation Error] ${message} - Device details: ${JSON.stringify(deviceDetails)}`
+        : `[Android Attestation Error] ${message}`,
+    );
+  }
+}
+
 /**
  * Simplified type definition for the Certificate Revocation List (CRL) object.
  */
@@ -36,18 +49,19 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   const { androidCrlUrl, googlePublicKey, x509Chain } = params;
 
   if (x509Chain.length <= 0) {
-    throw new Error("[Android Attestation] No certificates provided");
+    throw new AndroidAttestationError("No certificates provided");
   }
 
   validateIssuance(x509Chain, googlePublicKey);
   await validateRevocation(x509Chain, androidCrlUrl);
   const certWithExtension = validateKeyAttestationExtension(x509Chain);
 
-  validateExtension(certWithExtension, params);
+  const deviceDetails = validateExtension(certWithExtension, params);
 
   const hardwareKey = await jose.exportJWK(certWithExtension.publicKey);
 
   return {
+    deviceDetails,
     hardwareKey,
   };
 };
@@ -69,7 +83,7 @@ export const validateIssuance = (
     (c) => new Date(c.validFrom) <= now && now <= new Date(c.validTo),
   );
   if (!datesValid) {
-    throw new Error("[Android Attestation] Certificates expired");
+    throw new AndroidAttestationError("Certificates expired");
   }
 
   // Check that each certificate, except for the last, is issued by the subsequent one.
@@ -83,7 +97,7 @@ export const validateIssuance = (
           subject.checkIssued(issuer) === false ||
           subject.verify(issuer.publicKey) === false
         ) {
-          throw new Error("[Android Attestation] Certificate chain is invalid");
+          throw new AndroidAttestationError("Certificate chain is invalid");
         }
       }
     });
@@ -92,8 +106,8 @@ export const validateIssuance = (
   const publicKey = createPublicKey(googlePublicKey);
   const rootCert = x509Chain[x509Chain.length - 1]; // Last certificate in the chain is the root certificate
   if (!rootCert || !rootCert.verify(publicKey)) {
-    throw new Error(
-      "[Android Attestation] Root certificate is not signed by Google Hardware Attestation Root CA",
+    throw new AndroidAttestationError(
+      "Root certificate is not signed by Google Hardware Attestation Root CA",
     );
   }
 };
@@ -110,12 +124,12 @@ export const validateRevocation = async (
 ) => {
   const res = await fetch(androidCrlUrl, { method: "GET" });
   if (!res.ok) {
-    throw new Error("[Android Attestation] Failed to fetch CRL");
+    throw new AndroidAttestationError("Failed to fetch CRL");
   }
   const crl = (await res.json()) as CRL; // Add type assertion for crl
   const isRevoked = x509Chain.some((cert) => cert.serialNumber in crl.entries);
   if (isRevoked) {
-    throw new Error("[Android Attestation] Certificate is revoked");
+    throw new AndroidAttestationError("Certificate is revoked");
   }
   return x509Chain;
 };
@@ -149,7 +163,7 @@ const validateKeyAttestationExtension = (
     return certWithExtension;
   }
 
-  throw new Error("[Android Attestation] No key attestation extension found");
+  throw new AndroidAttestationError("No key attestation extension found");
 };
 
 const extractExtension = (certificate: X509Certificate, oid: string) => {
@@ -174,8 +188,8 @@ const validateExtension = (
 
   const extension = extractExtension(certWithExtension, KEY_OID);
   if (!extension) {
-    throw new Error(
-      "[Android Attestation] Unable to extract extension from certificate",
+    throw new AndroidAttestationError(
+      "Unable to extract extension from certificate",
     );
   }
 
@@ -185,6 +199,47 @@ const validateExtension = (
     extensionBerEncoded,
     NonStandardKeyDescription,
   );
+
+  let deviceDetails = keyDescription.teeEnforced.reduce(
+    (detailObj: AndroidDeviceDetails, currentValue) => {
+      if (currentValue.osVersion) {
+        return { ...detailObj, osVersion: currentValue.osVersion };
+      }
+      if (currentValue.osPatchLevel) {
+        return { ...detailObj, osPatchLevel: currentValue.osPatchLevel };
+      }
+      if (currentValue.vendorPatchLevel) {
+        return {
+          ...detailObj,
+          vendorPatchLevel: `${currentValue.vendorPatchLevel}`,
+        };
+      }
+      if (currentValue.bootPatchLevel) {
+        return {
+          ...detailObj,
+          bootPatchLevel: `${currentValue.bootPatchLevel}`,
+        };
+      }
+      if (currentValue.rootOfTrust) {
+        const rootOfTrust = currentValue.rootOfTrust;
+        return {
+          ...detailObj,
+          deviceLocked: rootOfTrust.deviceLocked,
+          verifiedBootState: rootOfTrust.verifiedBootState,
+        };
+      }
+      return detailObj;
+    },
+    { platform: "android" } as AndroidDeviceDetails,
+  );
+
+  deviceDetails = {
+    ...deviceDetails,
+    attestationSecurityLevel: keyDescription.attestationSecurityLevel,
+    attestationVersion: keyDescription.attestationVersion,
+    keymasterSecurityLevel: keyDescription.keymasterSecurityLevel,
+    keymasterVersion: keyDescription.keymasterVersion,
+  };
 
   /*
    * Check security level of attestation and key master.
@@ -197,14 +252,16 @@ const validateExtension = (
    * if the Android system becomes compromised.
    */
   if (keyDescription.attestationSecurityLevel <= 0) {
-    throw new Error(
-      `[Android Attestation] Attestation security level too low: ${keyDescription.attestationSecurityLevel}.`,
+    throw new AndroidAttestationError(
+      `Attestation security level too low: ${keyDescription.attestationSecurityLevel}.`,
+      deviceDetails,
     );
   }
 
   if (keyDescription.keymasterSecurityLevel <= 0) {
-    throw new Error(
-      `[Android Attestation] Key master security level too low: ${keyDescription.keymasterSecurityLevel}.`,
+    throw new AndroidAttestationError(
+      `Key master security level too low: ${keyDescription.keymasterSecurityLevel}.`,
+      deviceDetails,
     );
   }
 
@@ -214,8 +271,9 @@ const validateExtension = (
   ).toString("utf-8");
 
   if (receivedChallenge !== challenge) {
-    throw new Error(
-      "[Android Attestation] The received challenge does not match the one contained in the certificate.",
+    throw new AndroidAttestationError(
+      "The received challenge does not match the one contained in the certificate.",
+      deviceDetails,
     );
   }
 
@@ -226,8 +284,9 @@ const validateExtension = (
   );
 
   if (!softwareEnforced || !softwareEnforced.attestationApplicationId) {
-    throw new Error(
-      `[Android Attestation] Unable to found attestationApplicationId in key attestation.`,
+    throw new AndroidAttestationError(
+      `Unable to found attestationApplicationId in key attestation.`,
+      deviceDetails,
     );
   }
 
@@ -242,8 +301,9 @@ const validateExtension = (
   );
 
   if (!packageInfo) {
-    throw new Error(
-      `[Android Attestation] Unable to found packageInfo in key attestation.`,
+    throw new AndroidAttestationError(
+      `Unable to found packageInfo in key attestation.`,
+      deviceDetails,
     );
   }
 
@@ -256,8 +316,9 @@ const validateExtension = (
   );
 
   if (bundleIdentifiersCheck.length === 0) {
-    throw new Error(
-      `[Android Attestation] The bundle identifier ${packageName} does not match any of ${bundleIdentifiers}.`,
+    throw new AndroidAttestationError(
+      `The bundle identifier ${packageName} does not match any of ${bundleIdentifiers}.`,
+      deviceDetails,
     );
   }
 
@@ -266,8 +327,9 @@ const validateExtension = (
     (el) => el.rootOfTrust,
   );
   if (!teeEnforcedWithRoT || !teeEnforcedWithRoT.rootOfTrust) {
-    throw new Error(
-      `[Android Attestation] Unable to found a Root Of Trust in teeEnforced data.`,
+    throw new AndroidAttestationError(
+      `Unable to found a Root Of Trust in teeEnforced data.`,
+      deviceDetails,
     );
   }
 
@@ -275,7 +337,7 @@ const validateExtension = (
 
   // Check if bootloader in locked
   if (!rootOfTrust.deviceLocked) {
-    throw new Error(`[Android Attestation] BootLoader unlocked!`);
+    throw new AndroidAttestationError(`BootLoader unlocked!`, deviceDetails);
   }
 
   /*
@@ -290,8 +352,11 @@ const validateExtension = (
    * 3) Failed
    */
   if (rootOfTrust.verifiedBootState !== 0) {
-    throw new Error(
-      `[Android Attestation] VerifiedBootState is not verified: ${rootOfTrust.verifiedBootState}`,
+    throw new AndroidAttestationError(
+      `VerifiedBootState is not verified: ${rootOfTrust.verifiedBootState}`,
+      deviceDetails,
     );
   }
+
+  return deviceDetails;
 };

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/attestation.ts
@@ -56,7 +56,10 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   await validateRevocation(x509Chain, androidCrlUrl);
   const certWithExtension = validateKeyAttestationExtension(x509Chain);
 
-  const deviceDetails = validateExtension(certWithExtension, params);
+  const deviceDetails = {
+    ...validateExtension(certWithExtension, params),
+    x509Chain: x509Chain.map((x509) => x509.toString()),
+  };
 
   const hardwareKey = await jose.exportJWK(certWithExtension.publicKey);
 

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/index.ts
@@ -29,6 +29,7 @@ export const AndroidDeviceDetails = t.intersection([
     osVersion: t.number,
     vendorPatchLevel: t.string,
     verifiedBootState: t.number,
+    x509Chain: t.array(t.string),
   }),
 ]);
 

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/__test__/attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/__test__/attestation.spec.ts
@@ -32,6 +32,9 @@ describe("iOSAttestationValidation", () => {
       teamIdentifier,
     });
     const expectedResult = {
+      deviceDetails: {
+        platform: "ios",
+      },
       hardwareKey,
     };
 

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/attestation.ts
@@ -3,7 +3,7 @@ import { X509Certificate, createHash } from "crypto";
 import * as jose from "jose";
 import * as pkijs from "pkijs";
 
-import { iOsAttestation } from ".";
+import { IosDeviceDetails, iOsAttestation } from ".";
 
 const APPATTESTDEVELOP = Buffer.from("appattestdevelop").toString("hex");
 const APPATTESTPROD = Buffer.concat([
@@ -31,6 +31,10 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
     keyId,
     teamIdentifier,
   } = params;
+
+  const deviceDetails: IosDeviceDetails = {
+    platform: "ios",
+  };
 
   const { attStmt, authData } = decodedAttestation;
 
@@ -160,6 +164,7 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   const hardwareKey = await jose.exportJWK(clientCertificate.publicKey);
 
   return {
+    deviceDetails,
     hardwareKey,
   };
 };

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/index.ts
@@ -20,6 +20,11 @@ const buffer = new t.Type<Buffer, Buffer, unknown>(
   t.identity,
 );
 
+export const IosDeviceDetails = t.type({
+  platform: t.literal("ios"),
+});
+export type IosDeviceDetails = t.TypeOf<typeof IosDeviceDetails>;
+
 // iOS attestation type
 export const iOsAttestation = t.type({
   attStmt: t.type({

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -52,9 +52,10 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
       pipe(
         consumeNonce(walletInstanceRequest.challenge),
         RTE.chainW(() => validateAttestation(walletInstanceRequest)),
-        RTE.bind("walletInstance", ({ hardwareKey }) =>
+        RTE.bind("walletInstance", ({ deviceDetails, hardwareKey }) =>
           RTE.right({
             createdAt: new Date(),
+            deviceDetails,
             hardwareKey,
             id: walletInstanceRequest.hardwareKeyTag,
             isRevoked: false as const,

--- a/apps/io-wallet-user-func/src/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance.ts
@@ -7,10 +7,10 @@ import * as TE from "fp-ts/TaskEither";
 import { flow, pipe } from "fp-ts/function";
 import * as t from "io-ts";
 
+import { DeviceDetails } from "./attestation-service";
 import { EntityNotFoundError } from "./error";
 import { JwkPublicKey } from "./jwk";
 import { User } from "./user";
-
 class RevokedWalletInstance extends Error {
   name = "WalletInstanceRevoked";
   constructor() {
@@ -18,13 +18,18 @@ class RevokedWalletInstance extends Error {
   }
 }
 
-const WalletInstanceBase = t.type({
-  createdAt: IsoDateFromString,
-  hardwareKey: JwkPublicKey,
-  id: NonEmptyString,
-  signCount: t.number,
-  userId: User.props.id,
-});
+const WalletInstanceBase = t.intersection([
+  t.type({
+    createdAt: IsoDateFromString,
+    hardwareKey: JwkPublicKey,
+    id: NonEmptyString,
+    signCount: t.number,
+    userId: User.props.id,
+  }),
+  t.partial({
+    deviceDetails: DeviceDetails,
+  }),
+]);
 
 const WalletInstanceValid = t.intersection([
   WalletInstanceBase,


### PR DESCRIPTION
Add deviceDetails field to Wallet Instance calculated on the basis of the integrity check. Currently only Android allows you to have this additional information about the device, while for iOS only the platform field is added