### PR TITLE
feat: [SIW-1817] Add batch revocation of Wallet Instance Attested Key

### DIFF
--- a/.changeset/chatty-islands-perform.md
+++ b/.changeset/chatty-islands-perform.md
@@ -1,0 +1,6 @@
+---
+"io-wallet-common": patch
+"io-wallet-user-func": patch
+---
+
+Add batch revocation of Wallet Instances with revoked certificates

--- a/apps/io-wallet-user-func/src/android-key-attestation.ts
+++ b/apps/io-wallet-user-func/src/android-key-attestation.ts
@@ -7,7 +7,10 @@ import { pipe } from "fp-ts/lib/function";
 import { WalletInstanceValid } from "io-wallet-common/wallet-instance";
 
 import { AttestationServiceConfiguration } from "./app/config";
-import { validateRevocation } from "./infra/attestation-service/android/attestation";
+import {
+  validateIssuance,
+  validateRevocation,
+} from "./infra/attestation-service/android/attestation";
 import {
   WalletInstanceRepository,
   getAllValidWalletInstances,
@@ -35,6 +38,11 @@ const validateKeyAttestationChain = async (
       (cert) => new X509Certificate(cert),
     );
 
+    // Validate issuance and expiration of the certificates
+    validateIssuance(
+      x509Chain,
+      attestationServiceConfiguration.googlePublicKey,
+    );
     // Validate revocation of the certificates using the provided CRL URL
     await validateRevocation(
       x509Chain,

--- a/apps/io-wallet-user-func/src/android-key-attestation.ts
+++ b/apps/io-wallet-user-func/src/android-key-attestation.ts
@@ -1,0 +1,103 @@
+import { X509Certificate } from "crypto";
+import * as E from "fp-ts/lib/Either";
+import * as O from "fp-ts/lib/Option";
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import * as RA from "fp-ts/lib/ReadonlyArray";
+import * as TE from "fp-ts/lib/TaskEither";
+import { pipe } from "fp-ts/lib/function";
+import { WalletInstance } from "io-wallet-common/wallet-instance";
+
+import { AttestationServiceConfiguration } from "./app/config";
+import { validateRevocation } from "./infra/attestation-service/android/attestation";
+import {
+  WalletInstanceRepository,
+  revokeUserWalletInstances,
+} from "./wallet-instance";
+
+const validateChain = async (
+  walletInstance: WalletInstance,
+  androidCrlUrl: string,
+) => {
+  if (
+    walletInstance.deviceDetails &&
+    walletInstance.deviceDetails.platform === "android" &&
+    walletInstance.deviceDetails.x509Chain
+  ) {
+    const x509Chain = walletInstance.deviceDetails.x509Chain.map(
+      (cert) => new X509Certificate(cert),
+    );
+    await validateRevocation(x509Chain, androidCrlUrl, 4000);
+  }
+};
+
+const validateAttestedKeyAndRevoke =
+  (androidCrlUrl: string, walletInstanceRepository: WalletInstanceRepository) =>
+  (walletInstance: WalletInstance) => {
+    console.log(walletInstance.userId);
+    return pipe(
+      TE.tryCatch(
+        () => validateChain(walletInstance, androidCrlUrl),
+        E.toError,
+      ),
+      TE.fold(
+        () =>
+          revokeUserWalletInstances(walletInstance.userId, [walletInstance.id])(
+            { walletInstanceRepository },
+          ),
+        () => TE.right(undefined),
+      ),
+    );
+  };
+
+const fetchAndCheckAllWalletInstancesKey = (
+  walletInstanceRepository: WalletInstanceRepository,
+  attestationServiceConfiguration: AttestationServiceConfiguration,
+  continuationToken?: string,
+): TE.TaskEither<Error, void> =>
+  pipe(
+    walletInstanceRepository.getAllActive({
+      continuationToken,
+      maxItemCount: 3,
+    }),
+    TE.chain(
+      O.fold(
+        () => TE.right(undefined),
+        ({ continuationToken: newToken, walletInstances }) =>
+          pipe(
+            TE.fromIO(() =>
+              pipe(
+                walletInstances,
+                RA.map(
+                  validateAttestedKeyAndRevoke(
+                    attestationServiceConfiguration.androidCrlUrl,
+                    walletInstanceRepository,
+                  ),
+                ),
+              ),
+            ),
+            TE.chain(() =>
+              O.isSome(O.fromNullable(newToken))
+                ? fetchAndCheckAllWalletInstancesKey(
+                    walletInstanceRepository,
+                    attestationServiceConfiguration,
+                    newToken,
+                  )
+                : TE.right(undefined),
+            ),
+          ),
+      ),
+    ),
+  );
+
+export const checkWalletInstancesAttestedKeyRevocation: RTE.ReaderTaskEither<
+  {
+    attestationServiceConfiguration: AttestationServiceConfiguration;
+    walletInstanceRepository: WalletInstanceRepository;
+  },
+  Error,
+  void
+> = ({ attestationServiceConfiguration, walletInstanceRepository }) =>
+  fetchAndCheckAllWalletInstancesKey(
+    walletInstanceRepository,
+    attestationServiceConfiguration,
+  );

--- a/apps/io-wallet-user-func/src/android-key-attestation.ts
+++ b/apps/io-wallet-user-func/src/android-key-attestation.ts
@@ -82,7 +82,7 @@ const fetchAndCheckAllWalletInstancesKeyRevocation = (
   continuationToken?: string,
 ): TE.TaskEither<Error, void> =>
   pipe(
-    walletInstanceRepository.getAllActive({
+    walletInstanceRepository.getAllValid({
       continuationToken,
       maxItemCount: 50,
     }),

--- a/apps/io-wallet-user-func/src/android-key-attestation.ts
+++ b/apps/io-wallet-user-func/src/android-key-attestation.ts
@@ -111,7 +111,7 @@ export const checkWalletInstancesAttestedKeyRevocation: RTE.ReaderTaskEither<
   pipe(params, getAllValidWalletInstances, (generator) =>
     TE.tryCatch(async () => {
       for await (const result of generator) {
-        pipe(
+        await pipe(
           result,
           E.fold(
             () => TE.right(undefined),

--- a/apps/io-wallet-user-func/src/android-key-attestation.ts
+++ b/apps/io-wallet-user-func/src/android-key-attestation.ts
@@ -14,13 +14,13 @@ import {
   revokeUserWalletInstances,
 } from "./wallet-instance";
 
-type WalletInstanceValidWithDetails = {
+type WalletInstanceValidWithAndroidCertificatesChain = {
   deviceDetails: { platform: string; x509Chain: string[] };
 } & WalletInstanceValid;
 
-const hasValidChain = (
+const hasAndroidCertificatesChain = (
   walletInstance: WalletInstanceValid,
-): walletInstance is WalletInstanceValidWithDetails =>
+): walletInstance is WalletInstanceValidWithAndroidCertificatesChain =>
   !!walletInstance.deviceDetails &&
   walletInstance.deviceDetails.platform === "android" &&
   !!walletInstance.deviceDetails.x509Chain;
@@ -30,7 +30,7 @@ const validateKeyAttestationChain = async (
   attestationServiceConfiguration: AttestationServiceConfiguration,
 ) => {
   // Check if device details exist and the platform is Android with a valid x509 chain. For iOS is not necessary.
-  if (hasValidChain(walletInstance)) {
+  if (hasAndroidCertificatesChain(walletInstance)) {
     const x509Chain = walletInstance.deviceDetails.x509Chain.map(
       (cert) => new X509Certificate(cert),
     );

--- a/apps/io-wallet-user-func/src/android-key-attestation.ts
+++ b/apps/io-wallet-user-func/src/android-key-attestation.ts
@@ -12,6 +12,7 @@ import { AttestationServiceConfiguration } from "./app/config";
 import { validateRevocation } from "./infra/attestation-service/android/attestation";
 import {
   WalletInstanceRepository,
+  getAllValidWalletInstances,
   revokeUserWalletInstances,
 } from "./wallet-instance";
 
@@ -82,7 +83,9 @@ const fetchAndCheckAllWalletInstancesKeyRevocation = (
   continuationToken?: string,
 ): TE.TaskEither<Error, void> =>
   pipe(
-    walletInstanceRepository.getAllValid({
+    // TODO SIW-1818
+    { walletInstanceRepository },
+    getAllValidWalletInstances({
       continuationToken,
       maxItemCount: 50,
     }),

--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -182,5 +182,5 @@ app.timer("checkWalletInstancesAttestedKeyRevocation", {
     telemetryClient: appInsightsClient,
     walletInstanceRepository,
   }),
-  schedule: "*/10 * * * * *",
+  schedule: "0 0 * * * *",
 });

--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -2,6 +2,7 @@ import ai from "@/infra/azure/appinsights/start";
 import withAppInsights from "@/infra/azure/appinsights/wrapper-handler";
 import { CosmosDbNonceRepository } from "@/infra/azure/cosmos/nonce";
 import { CosmosDbWalletInstanceRepository } from "@/infra/azure/cosmos/wallet-instance";
+import { CheckWalletInstancesAttestedKeyRevocationFunction } from "@/infra/azure/functions/check-wallet-instances-keys-revocation";
 import { CreateWalletAttestationFunction } from "@/infra/azure/functions/create-wallet-attestation";
 import { CreateWalletInstanceFunction } from "@/infra/azure/functions/create-wallet-instance";
 import { GenerateEntityConfigurationFunction } from "@/infra/azure/functions/generate-entity-configuration";
@@ -172,4 +173,14 @@ app.http("setCurrentWalletInstanceStatus", {
   ),
   methods: ["PUT"],
   route: "wallet-instances/current/status",
+});
+
+app.timer("checkWalletInstancesAttestedKeyRevocation", {
+  handler: CheckWalletInstancesAttestedKeyRevocationFunction({
+    attestationServiceConfiguration: config.attestationService,
+    inputDecoder: t.unknown,
+    telemetryClient: appInsightsClient,
+    walletInstanceRepository,
+  }),
+  schedule: "*/10 * * * * *",
 });

--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -182,5 +182,5 @@ app.timer("checkWalletInstancesAttestedKeyRevocation", {
     telemetryClient: appInsightsClient,
     walletInstanceRepository,
   }),
-  schedule: "0 0 * * * *",
+  schedule: "*/10 * * * * *",
 });

--- a/apps/io-wallet-user-func/src/infra/azure/functions/check-wallet-instances-keys-revocation.ts
+++ b/apps/io-wallet-user-func/src/infra/azure/functions/check-wallet-instances-keys-revocation.ts
@@ -1,0 +1,6 @@
+import { CheckWalletInstancesAttestedKeyRevocationHandler } from "@/infra/handlers/check-wallet-instances-keys-revocation";
+import { azureFunction } from "@pagopa/handler-kit-azure-func";
+
+export const CheckWalletInstancesAttestedKeyRevocationFunction = azureFunction(
+  CheckWalletInstancesAttestedKeyRevocationHandler,
+);

--- a/apps/io-wallet-user-func/src/infra/handlers/check-wallet-instances-keys-revocation.ts
+++ b/apps/io-wallet-user-func/src/infra/handlers/check-wallet-instances-keys-revocation.ts
@@ -1,0 +1,19 @@
+import { checkWalletInstancesAttestedKeyRevocation } from "@/android-key-attestation";
+import * as H from "@pagopa/handler-kit";
+import { pipe } from "fp-ts/function";
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import { sendTelemetryException } from "io-wallet-common/infra/azure/appinsights/telemetry";
+
+export const CheckWalletInstancesAttestedKeyRevocationHandler = H.of(() =>
+  pipe(
+    checkWalletInstancesAttestedKeyRevocation,
+    RTE.orElseFirstW((error) =>
+      pipe(
+        sendTelemetryException(error, {
+          functionName: "checkWalletInstancesAttestedKeyRevocation",
+        }),
+        RTE.fromReader,
+      ),
+    ),
+  ),
+);

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
@@ -73,7 +73,9 @@ const walletInstanceRepository: WalletInstanceRepository = {
       }),
     ),
   getAllByUserId: () => TE.left(new Error("not implemented")),
-  getAllValid: () => TE.left(new Error("not implemented")),
+  getAllValid: function () {
+    throw new Error("not implemented");
+  },
   getLastByUserId: () => TE.left(new Error("not implemented")),
   insert: () => TE.left(new Error("not implemented")),
 };
@@ -204,7 +206,9 @@ describe("CreateWalletAttestationHandler", async () => {
           }),
         ),
       getAllByUserId: () => TE.left(new Error("not implemented")),
-      getAllValid: () => TE.left(new Error("not implemented")),
+      getAllValid: function () {
+        throw new Error("not implemented");
+      },
       getLastByUserId: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -250,7 +254,9 @@ describe("CreateWalletAttestationHandler", async () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       get: () => TE.right(O.none),
       getAllByUserId: () => TE.left(new Error("not implemented")),
-      getAllValid: () => TE.left(new Error("not implemented")),
+      getAllValid: function () {
+        throw new Error("not implemented");
+      },
       getLastByUserId: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-attestation.spec.ts
@@ -73,6 +73,7 @@ const walletInstanceRepository: WalletInstanceRepository = {
       }),
     ),
   getAllByUserId: () => TE.left(new Error("not implemented")),
+  getAllValid: () => TE.left(new Error("not implemented")),
   getLastByUserId: () => TE.left(new Error("not implemented")),
   insert: () => TE.left(new Error("not implemented")),
 };
@@ -203,6 +204,7 @@ describe("CreateWalletAttestationHandler", async () => {
           }),
         ),
       getAllByUserId: () => TE.left(new Error("not implemented")),
+      getAllValid: () => TE.left(new Error("not implemented")),
       getLastByUserId: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -248,6 +250,7 @@ describe("CreateWalletAttestationHandler", async () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       get: () => TE.right(O.none),
       getAllByUserId: () => TE.left(new Error("not implemented")),
+      getAllValid: () => TE.left(new Error("not implemented")),
       getLastByUserId: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
@@ -41,6 +41,7 @@ describe("CreateWalletInstanceHandler", () => {
     batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.right(O.some([])),
+    getAllValid: () => TE.left(new Error("not implemented")),
     getLastByUserId: () => TE.left(new Error("not implemented")),
     insert: () => TE.right(undefined),
   };
@@ -164,6 +165,7 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("failed on insert!")),
       };
@@ -199,6 +201,7 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("failed on getAllByUserId!")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };
@@ -235,6 +238,7 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
@@ -41,7 +41,9 @@ describe("CreateWalletInstanceHandler", () => {
     batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.right(O.some([])),
-    getAllValid: () => TE.left(new Error("not implemented")),
+    getAllValid: function () {
+      throw new Error("not implemented");
+    },
     getLastByUserId: () => TE.left(new Error("not implemented")),
     insert: () => TE.right(undefined),
   };
@@ -165,7 +167,9 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("failed on insert!")),
       };
@@ -201,7 +205,9 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("failed on getAllByUserId!")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };
@@ -238,7 +244,9 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-current-wallet-instance.status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-current-wallet-instance.status.spec.ts
@@ -23,7 +23,9 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.left(new Error("not implemented")),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.left(new Error("not implemented")),
-    getAllValid: () => TE.left(new Error("not implemented")),
+    getAllValid: function () {
+      throw new Error("not implemented");
+    },
     getLastByUserId: () =>
       TE.right(
         O.some({
@@ -298,7 +300,9 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       get: () => TE.left(new Error("not implemented")),
       getAllByUserId: () => TE.left(new Error("not implemented")),
-      getAllValid: () => TE.left(new Error("not implemented")),
+      getAllValid: function () {
+        throw new Error("not implemented");
+      },
       getLastByUserId: () => TE.right(O.none),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -335,7 +339,9 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () => TE.left(new Error("failed on getLastByUserId!")),
         insert: () => TE.left(new Error("not implemented")),
       };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-current-wallet-instance.status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-current-wallet-instance.status.spec.ts
@@ -23,6 +23,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.left(new Error("not implemented")),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.left(new Error("not implemented")),
+    getAllValid: () => TE.left(new Error("not implemented")),
     getLastByUserId: () =>
       TE.right(
         O.some({
@@ -297,6 +298,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       get: () => TE.left(new Error("not implemented")),
       getAllByUserId: () => TE.left(new Error("not implemented")),
+      getAllValid: () => TE.left(new Error("not implemented")),
       getLastByUserId: () => TE.right(O.none),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -333,6 +335,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("failed on getLastByUserId!")),
         insert: () => TE.left(new Error("not implemented")),
       };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-current-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-current-wallet-instance-status.spec.ts
@@ -17,7 +17,9 @@ describe("SetCurrentWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.left(new Error("not implemented")),
-    getAllValid: () => TE.left(new Error("not implemented")),
+    getAllValid: function () {
+      throw new Error("not implemented");
+    },
     getLastByUserId: () =>
       TE.right(
         O.some({
@@ -137,7 +139,9 @@ describe("SetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };
@@ -167,7 +171,9 @@ describe("SetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () =>
           TE.left(new ServiceUnavailableError("failed on getLastByUserId!")),
         insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-current-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-current-wallet-instance-status.spec.ts
@@ -17,6 +17,7 @@ describe("SetCurrentWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.left(new Error("not implemented")),
+    getAllValid: () => TE.left(new Error("not implemented")),
     getLastByUserId: () =>
       TE.right(
         O.some({
@@ -136,6 +137,7 @@ describe("SetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };
@@ -165,6 +167,7 @@ describe("SetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () =>
           TE.left(new ServiceUnavailableError("failed on getLastByUserId!")),
         insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-wallet-instance-status.spec.ts
@@ -17,7 +17,9 @@ describe("SetWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.left(new Error("not implemented")),
-    getAllValid: () => TE.left(new Error("not implemented")),
+    getAllValid: function () {
+      throw new Error("not implemented");
+    },
     getLastByUserId: () => TE.left(new Error("not implemented")),
     insert: () => TE.left(new Error("not implemented")),
   };
@@ -414,7 +416,9 @@ describe("SetWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
-        getAllValid: () => TE.left(new Error("not implemented")),
+        getAllValid: function () {
+          throw new Error("not implemented");
+        },
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/set-wallet-instance-status.spec.ts
@@ -17,6 +17,7 @@ describe("SetWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.right(undefined),
     get: () => TE.left(new Error("not implemented")),
     getAllByUserId: () => TE.left(new Error("not implemented")),
+    getAllValid: () => TE.left(new Error("not implemented")),
     getLastByUserId: () => TE.left(new Error("not implemented")),
     insert: () => TE.left(new Error("not implemented")),
   };
@@ -413,6 +414,7 @@ describe("SetWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         get: () => TE.left(new Error("not implemented")),
         getAllByUserId: () => TE.left(new Error("not implemented")),
+        getAllValid: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
       };

--- a/apps/io-wallet-user-func/src/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance.ts
@@ -1,4 +1,6 @@
+import * as E from "fp-ts/Either";
 import * as O from "fp-ts/Option";
+import * as R from "fp-ts/Reader";
 import * as RTE from "fp-ts/ReaderTaskEither";
 import * as RA from "fp-ts/ReadonlyArray";
 import * as TE from "fp-ts/TaskEither";
@@ -35,16 +37,7 @@ export interface WalletInstanceRepository {
   getAllByUserId: (
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance[]>>;
-  getAllValid: (options: {
-    continuationToken?: string;
-    maxItemCount?: number;
-  }) => TE.TaskEither<
-    Error,
-    O.Option<{
-      continuationToken?: string;
-      walletInstances: WalletInstanceValid[];
-    }>
-  >;
+  getAllValid: () => AsyncGenerator<E.Either<Error, WalletInstanceValid>>;
   getLastByUserId: (
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance>>;
@@ -168,17 +161,7 @@ export const revokeUserValidWalletInstancesExceptOne: (
     ),
   );
 
-export const getAllValidWalletInstances: (options: {
-  continuationToken?: string;
-  maxItemCount?: number;
-}) => RTE.ReaderTaskEither<
+export const getAllValidWalletInstances: R.Reader<
   WalletInstanceEnvironment,
-  Error,
-  O.Option<{
-    continuationToken?: string;
-    walletInstances: WalletInstanceValid[];
-  }>
-> =
-  (options) =>
-  ({ walletInstanceRepository }) =>
-    walletInstanceRepository.getAllValid(options);
+  AsyncGenerator<E.Either<Error, WalletInstanceValid>>
+> = ({ walletInstanceRepository }) => walletInstanceRepository.getAllValid();

--- a/apps/io-wallet-user-func/src/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance.ts
@@ -167,3 +167,18 @@ export const revokeUserValidWalletInstancesExceptOne: (
       revokeUserWalletInstances(userId, validWalletInstances),
     ),
   );
+
+export const getAllValidWalletInstances: (options: {
+  continuationToken?: string;
+  maxItemCount?: number;
+}) => RTE.ReaderTaskEither<
+  WalletInstanceEnvironment,
+  Error,
+  O.Option<{
+    continuationToken?: string;
+    walletInstances: WalletInstanceValid[];
+  }>
+> =
+  (options) =>
+  ({ walletInstanceRepository }) =>
+    walletInstanceRepository.getAllValid(options);

--- a/apps/io-wallet-user-func/src/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance.ts
@@ -32,6 +32,13 @@ export interface WalletInstanceRepository {
     id: WalletInstance["id"],
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance>>;
+  getAllActive: (options: {
+    continuationToken?: string;
+    maxItemCount?: number;
+  }) => TE.TaskEither<
+    Error,
+    O.Option<{ continuationToken?: string; walletInstances: WalletInstance[] }>
+  >;
   getAllByUserId: (
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance[]>>;

--- a/apps/io-wallet-user-func/src/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance.ts
@@ -32,16 +32,19 @@ export interface WalletInstanceRepository {
     id: WalletInstance["id"],
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance>>;
-  getAllActive: (options: {
+  getAllByUserId: (
+    userId: WalletInstance["userId"],
+  ) => TE.TaskEither<Error, O.Option<WalletInstance[]>>;
+  getAllValid: (options: {
     continuationToken?: string;
     maxItemCount?: number;
   }) => TE.TaskEither<
     Error,
-    O.Option<{ continuationToken?: string; walletInstances: WalletInstance[] }>
+    O.Option<{
+      continuationToken?: string;
+      walletInstances: WalletInstanceValid[];
+    }>
   >;
-  getAllByUserId: (
-    userId: WalletInstance["userId"],
-  ) => TE.TaskEither<Error, O.Option<WalletInstance[]>>;
   getLastByUserId: (
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance>>;

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -18,7 +18,7 @@ const WalletInstanceBase = t.intersection([
   }),
 ]);
 
-const WalletInstanceValid = t.intersection([
+export const WalletInstanceValid = t.intersection([
   WalletInstanceBase,
   t.type({
     isRevoked: t.literal(false),


### PR DESCRIPTION
Introduces a new function that runs every day at midnight to check if there is any active Wallet Instance with a revoked certificate and therefore the Wallet Instance should be revoked as well. When it is revoked an event on ApplicationInsights is fired.