### PR TITLE
chore: Refactor to use ValidationResult

### DIFF
--- a/.changeset/hot-taxis-kiss.md
+++ b/.changeset/hot-taxis-kiss.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-user-func": patch
+---
+
+Refactor to validation result for attestation/assertion library

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/__test__/assertion.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/__test__/assertion.spec.ts
@@ -73,7 +73,7 @@ describe("AndroidAssertionValidation", async () => {
       "-sYXRdwJA3hvue3mKpYrOZ9zSPC7b4mbgzJmdZEDO5w",
     );
 
-    expect(responseValidated).toEqual(true);
+    expect(responseValidated).toEqual({ success: true });
   });
 
   it("should validate integrity response in development mode", () => {
@@ -104,6 +104,6 @@ describe("AndroidAssertionValidation", async () => {
       "-sYXRdwJA3hvue3mKpYrOZ9zSPC7b4mbgzJmdZEDO5w",
     );
 
-    expect(responseValidated).toEqual(true);
+    expect(responseValidated).toEqual({ success: true });
   });
 });

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/__test__/attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/__test__/attestation.spec.ts
@@ -7,7 +7,6 @@ import { X509Certificate } from "crypto";
 import { describe, expect, it } from "vitest";
 
 import { base64ToPem } from "..";
-import { AndroidAttestationError } from "../../errors";
 import { validateRevocation, verifyAttestation } from "../attestation";
 import { androidMockData } from "./config";
 
@@ -47,6 +46,7 @@ describe("AndroidAttestationValidation", () => {
         x509Chain: x509Chain.map((el) => el.toString()),
       },
       hardwareKey,
+      success: true,
     };
 
     await expect(result).resolves.toEqual(expectedResult);
@@ -59,14 +59,14 @@ describe("AndroidAttestationValidation", () => {
       ANDROID_CRL_URL,
       4000,
     );
-    expect(validation).toBe(validChain);
+    expect(validation).toHaveProperty("success", true);
   });
 
-  it("should return an exception for revoked chain", async () => {
+  it("should return an error for revoked chain", async () => {
     const invalidChain = revokedX509Chain.map((c) => new X509Certificate(c));
 
     await expect(
       validateRevocation(invalidChain, ANDROID_CRL_URL, 4000),
-    ).rejects.toThrow(AndroidAttestationError);
+    ).resolves.toHaveProperty("success", false);
   });
 });

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/assertion.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/assertion.ts
@@ -280,7 +280,7 @@ export const validateIntegrityResponse = (
 
   if (deviceRecognitionVerdict.indexOf("MEETS_DEVICE_INTEGRITY") === -1) {
     return {
-      reason: `Device no meets integrity check.`,
+      reason: `Device doesn't meet integrity check.`,
       success: false,
     };
   }

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/attestation.ts
@@ -421,7 +421,6 @@ const validateExtension = async (
   return {
     deviceDetails,
     hardwareKey,
-
     success: true,
   };
 };

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/index.ts
@@ -93,8 +93,8 @@ export const validateAndroidAssertion = (
     E.chain(J.parse),
     E.mapLeft(
       () =>
-        new Error(
-          "[Android Assertion] Unable to parse Google App Credentials string",
+        new AndroidAssertionError(
+          "Unable to parse Google App Credentials string",
         ),
     ),
     E.chainW(parse(GoogleAppCredentials, "Invalid Google App Credentials")),

--- a/apps/io-wallet-user-func/src/infra/attestation-service/android/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/android/index.ts
@@ -10,7 +10,7 @@ import * as S from "fp-ts/lib/string";
 import { JwkPublicKey } from "io-wallet-common/jwk";
 
 import { ValidatedAttestation } from "../../attestation-service";
-import { AndroidAttestationError } from "../errors";
+import { AndroidAssertionError, AndroidAttestationError } from "../errors";
 import { GoogleAppCredentials, verifyAssertion } from "./assertion";
 import { verifyAttestation } from "./attestation";
 
@@ -35,10 +35,7 @@ export const validateAndroidAttestation = (
         E.tryCatch(
           () => new X509Certificate(cert),
           () =>
-            new AndroidAttestationError(
-              `Unable to decode X509 certificate`,
-              {},
-            ),
+            new AndroidAttestationError(`Unable to decode X509 certificate`),
         ),
       ),
     ),
@@ -57,6 +54,13 @@ export const validateAndroidAttestation = (
               x509Chain,
             }),
           E.toError,
+        ),
+        TE.chain((attestationValidationResult) =>
+          attestationValidationResult.success
+            ? TE.right(attestationValidationResult)
+            : TE.left(
+                new AndroidAttestationError(attestationValidationResult.reason),
+              ),
         ),
         TE.chainW(({ deviceDetails, hardwareKey }) =>
           pipe(
@@ -111,5 +115,10 @@ export const validateAndroidAssertion = (
           }),
         E.toError,
       ),
+    ),
+    TE.chain((assertionValidationResult) =>
+      assertionValidationResult.success
+        ? TE.right(undefined)
+        : TE.left(new AndroidAssertionError(assertionValidationResult.reason)),
     ),
   );

--- a/apps/io-wallet-user-func/src/infra/attestation-service/errors.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/errors.ts
@@ -1,24 +1,7 @@
-import { X509Certificate } from "crypto";
-import { AndroidDeviceDetails } from "io-wallet-common/device-details";
-
 export class AndroidAttestationError extends Error {
   name = "AndroidAttestationError";
-  constructor(
-    message: string,
-    {
-      deviceDetails,
-      x509Chain,
-    }: {
-      deviceDetails?: AndroidDeviceDetails;
-      x509Chain?: readonly X509Certificate[];
-    },
-  ) {
-    const finalMessage =
-      `[Android Attestation Error] ${message}` +
-      (x509Chain ? `\nx509Chain: ${JSON.stringify(x509Chain)}` : "") +
-      (deviceDetails
-        ? `\nDevice details: ${JSON.stringify(deviceDetails)}`
-        : "");
+  constructor(message: string) {
+    const finalMessage = `[Android Attestation Error] ${message}`;
 
     super(finalMessage);
   }
@@ -44,3 +27,7 @@ export class IosAttestationError extends Error {
     super(`[iOS Attestation Error] ${message}`);
   }
 }
+
+export type ValidationResult =
+  | { reason: string; success: false }
+  | { success: true };

--- a/apps/io-wallet-user-func/src/infra/attestation-service/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/index.ts
@@ -137,7 +137,7 @@ export class MobileAttestationService implements AttestationService {
               this.#configuration.httpRequestTimeout,
             ),
           ],
-          RA.wilt(T.ApplicativePar)(identity),
+          RA.wilt(T.ApplicativeSeq)(identity),
           T.map(getErrorsOrFirstValidValue),
         ),
       ),

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/__test__/assertion.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/__test__/assertion.spec.ts
@@ -30,6 +30,6 @@ describe("iOSAssertionValidation", () => {
       teamIdentifier,
     });
 
-    await expect(result).resolves.empty;
+    await expect(result).resolves.toEqual({ success: true });
   });
 });

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/__test__/attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/__test__/attestation.spec.ts
@@ -36,6 +36,7 @@ describe("iOSAttestationValidation", () => {
         platform: "ios",
       },
       hardwareKey,
+      success: true,
     };
 
     await expect(result).resolves.toEqual(expectedResult);

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/assertion.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/assertion.ts
@@ -3,7 +3,7 @@ import { JwkPublicKey } from "io-wallet-common/jwk";
 import { exportSPKI, importJWK } from "jose";
 
 import { iOsAssertion } from ".";
-import { IosAssertionError } from "../errors";
+import { ValidationResult } from "../errors";
 
 export interface VerifyAssertionParams {
   bundleIdentifiers: string[];
@@ -15,7 +15,9 @@ export interface VerifyAssertionParams {
   teamIdentifier: string;
 }
 
-export const verifyAssertion = async (params: VerifyAssertionParams) => {
+export const verifyAssertion = async (
+  params: VerifyAssertionParams,
+): Promise<ValidationResult> => {
   const {
     bundleIdentifiers,
     clientData,
@@ -33,7 +35,10 @@ export const verifyAssertion = async (params: VerifyAssertionParams) => {
   const joseHardwareKey = await importJWK(hardwareKey);
 
   if (!("type" in joseHardwareKey)) {
-    throw new IosAssertionError("Invalid Hardware Key format");
+    return {
+      reason: "Invalid Hardware Key format",
+      success: false,
+    };
   }
 
   const publicHardwareKeyPem = await exportSPKI(joseHardwareKey);
@@ -54,7 +59,10 @@ export const verifyAssertion = async (params: VerifyAssertionParams) => {
     !skipSignatureValidation &&
     !verifier.verify(publicHardwareKeyPem, signature)
   ) {
-    throw new IosAssertionError("invalid signature");
+    return {
+      reason: "Invalid signature",
+      success: false,
+    };
   }
 
   // 5. Compute the SHA256 hash of your app’s App ID, and verify that it’s the same as the authenticator data’s RP ID hash.
@@ -70,12 +78,19 @@ export const verifyAssertion = async (params: VerifyAssertionParams) => {
   );
 
   if (bundleIdentifiersCheck.length === 0) {
-    throw new IosAssertionError("appId does not match");
+    return {
+      reason: "appId does not match",
+      success: false,
+    };
   }
 
   // 6. Verify that the authenticator data’s counter field is larger than the stored signCount.
   const nextSignCount = authenticatorData.subarray(33, 37).readInt32BE();
   if (nextSignCount <= signCount) {
-    throw new IosAssertionError("invalid signCount");
+    return {
+      reason: "Invalid signCount",
+      success: false,
+    };
   }
+  return { success: true };
 };

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/attestation.ts
@@ -5,7 +5,6 @@ import * as jose from "jose";
 import * as pkijs from "pkijs";
 
 import { iOsAttestation } from ".";
-import { IosAttestationError } from "../errors";
 
 const APPATTESTDEVELOP = Buffer.from("appattestdevelop").toString("hex");
 const APPATTESTPROD = Buffer.concat([
@@ -23,7 +22,17 @@ export interface VerifyAttestationParams {
   teamIdentifier: string;
 }
 
-export const verifyAttestation = async (params: VerifyAttestationParams) => {
+type IosAttestationValidationResult =
+  | {
+      deviceDetails: IosDeviceDetails;
+      hardwareKey: jose.JWK;
+      success: true;
+    }
+  | { reason: string; success: false };
+
+export const verifyAttestation = async (
+  params: VerifyAttestationParams,
+): Promise<IosAttestationValidationResult> => {
   const {
     allowDevelopmentEnvironment,
     appleRootCertificate,
@@ -43,7 +52,10 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   // Convert X509 string to X509Certificate obj
   const rootCertificate = new X509Certificate(appleRootCertificate);
   if (!rootCertificate) {
-    throw new IosAttestationError("Invalid Apple root certificate");
+    return {
+      reason: "Invalid Apple root certificate",
+      success: false,
+    };
   }
 
   // https://developer.apple.com/documentation/devicecheck/validating_apps_that_connect_to_your_server
@@ -58,12 +70,17 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
 
   if (subCaCertificate !== undefined) {
     if (!subCaCertificate.verify(rootCertificate.publicKey)) {
-      throw new Error(
-        "sub CA certificate is not signed by Apple App Attestation Root CA",
-      );
+      return {
+        reason:
+          "sub CA certificate is not signed by Apple App Attestation Root CA",
+        success: false,
+      };
     }
   } else {
-    throw new IosAttestationError("no sub CA certificate found");
+    return {
+      reason: "No sub CA certificate found",
+      success: false,
+    };
   }
 
   const clientCertificate = certificates.find((certificate) =>
@@ -72,12 +89,17 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
 
   if (clientCertificate !== undefined) {
     if (!clientCertificate.verify(subCaCertificate.publicKey)) {
-      throw new Error(
-        "client CA certificate is not signed by Apple App Attestation CA 1",
-      );
+      return {
+        reason:
+          "Client CA certificate is not signed by Apple App Attestation CA",
+        success: false,
+      };
     }
   } else {
-    throw new IosAttestationError("no client CA certificate found");
+    return {
+      reason: "No client CA certificate found",
+      success: false,
+    };
   }
 
   // 2. Create clientDataHash as the SHA256 hash of the one-time challenge your server sends to your
@@ -107,7 +129,10 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
       .valueHex,
   ).toString("hex");
   if (actualNonce !== nonce) {
-    throw new IosAttestationError("nonce does not match");
+    return {
+      reason: "Nonce does not match",
+      success: false,
+    };
   }
 
   // 5. Create the SHA256 hash of the public key in credCert, and verify that it matches the key identifier from your app
@@ -118,7 +143,10 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
     .update(publicKey.toString("hex"), "hex") // Convert publicKey to hexadecimal string
     .digest("base64url");
   if (publicKeyHash !== keyId) {
-    throw new IosAttestationError("keyId does not match");
+    return {
+      reason: "keyId does not match",
+      success: false,
+    };
   }
 
   // 6. Compute the SHA256 hash of your app’s App ID, and verify that it’s the same as the authenticator data’s RP ID hash.
@@ -133,14 +161,20 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   );
 
   if (bundleIdentifiersCheck.length === 0) {
-    throw new IosAttestationError("appId does not match");
+    return {
+      reason: "appId does not match",
+      success: false,
+    };
   }
 
   // 7. Verify that the authenticator data’s counter field equals 0.
   const signCount = authData.subarray(33, 37).readInt32BE();
 
   if (signCount !== 0) {
-    throw new IosAttestationError("signCount is not 0");
+    return {
+      reason: "signCount is not 0",
+      success: false,
+    };
   }
 
   // 8. Verify that the authenticator data’s aaguid field is either appattestdevelop if operating in the development
@@ -148,11 +182,17 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   const aaguid = authData.subarray(37, 53).toString("hex");
 
   if (aaguid !== APPATTESTDEVELOP && aaguid !== APPATTESTPROD) {
-    throw new IosAttestationError("aaguid is not valid");
+    return {
+      reason: "aaguid is not valid",
+      success: false,
+    };
   }
 
   if (aaguid === APPATTESTDEVELOP && !allowDevelopmentEnvironment) {
-    throw new IosAttestationError("development environment is not allowed");
+    return {
+      reason: "development environment is not allowed",
+      success: false,
+    };
   }
 
   // 9. Verify that the authenticator data’s credentialId field is the same as the key identifier.
@@ -160,7 +200,10 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   const credentialId = authData.subarray(55, 55 + credentialIdLength);
 
   if (credentialId.toString("base64url") !== keyId) {
-    throw new IosAttestationError("credentialId does not match");
+    return {
+      reason: "credentialId does not match",
+      success: false,
+    };
   }
 
   const hardwareKey = await jose.exportJWK(clientCertificate.publicKey);
@@ -168,5 +211,6 @@ export const verifyAttestation = async (params: VerifyAttestationParams) => {
   return {
     deviceDetails,
     hardwareKey,
+    success: true,
   };
 };

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/index.ts
@@ -9,6 +9,7 @@ import * as t from "io-ts";
 import { JwkPublicKey } from "io-wallet-common/jwk";
 
 import { ValidatedAttestation } from "../../../attestation-service";
+import { IosAssertionError, IosAttestationError } from "../errors";
 import { verifyAssertion } from "./assertion";
 import { verifyAttestation } from "./attestation";
 
@@ -64,6 +65,13 @@ export const validateiOSAttestation = (
               teamIdentifier,
             }),
           E.toError,
+        ),
+        TE.chain((attestationValidationResult) =>
+          attestationValidationResult.success
+            ? TE.right(attestationValidationResult)
+            : TE.left(
+                new IosAttestationError(attestationValidationResult.reason),
+              ),
         ),
         TE.chainW((result) =>
           pipe(
@@ -124,5 +132,10 @@ export const validateiOSAssertion = (
           }),
         E.toError,
       ),
+    ),
+    TE.chain((assertionValidationResult) =>
+      assertionValidationResult.success
+        ? TE.right(undefined)
+        : TE.left(new IosAssertionError(assertionValidationResult.reason)),
     ),
   );

--- a/apps/io-wallet-user-func/src/infra/attestation-service/ios/index.ts
+++ b/apps/io-wallet-user-func/src/infra/attestation-service/ios/index.ts
@@ -45,7 +45,7 @@ export const validateiOSAttestation = (
   pipe(
     E.tryCatch(
       () => decode(data),
-      () => new Error(`[iOS Attestation] Unable to decode data`),
+      () => new IosAttestationError(`Unable to decode data`),
     ),
     E.chainW(
       parse(iOsAttestation, "[iOS Attestation] attestation format is invalid"),


### PR DESCRIPTION
It removes old code that used exceptions in favor of a more complete data structure organized as follows:
```ts
export type ValidationResult =
  | { reason: string; success: false }
  | { success: true };

```

This allows you to separate runtime errors from validation errors.