### PR TITLE
[CES-505] Move Cosmos DB secondary region to Spain Central

### DIFF
--- a/infra/resources/prod/locals.tf
+++ b/infra/resources/prod/locals.tf
@@ -14,7 +14,7 @@ locals {
   project_legacy = "${local.prefix}-${local.env_short}"
 
   location           = "italynorth"
-  secondary_location = "germanywestcentral"
+  secondary_location = "spaincentral"
 
   apim = {
     name                = "${local.project_legacy}-apim-v2-api"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Replace Germany West Central with Spain Central as Cosmos DB read location

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Germany West Central is always at full capacity and not available for Cosmos. For this reason, all Cosmos now uses Spain Central as read location. This PR aligns Wallet Cosmos to others

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
