### PR TITLE
feat: Add revocation reason to Revoked Wallet Instance

### DIFF
--- a/.changeset/light-experts-repair.md
+++ b/.changeset/light-experts-repair.md
@@ -1,0 +1,6 @@
+---
+"io-wallet-common": patch
+"io-wallet-user-func": patch
+---
+
+Add revocation reason to Wallet Instance

--- a/apps/io-wallet-user-func/src/certificates.ts
+++ b/apps/io-wallet-user-func/src/certificates.ts
@@ -24,7 +24,7 @@ export const validateIssuance = (
     );
     if (!datesValid) {
       return {
-        reason: "Certificates expired",
+        reason: `Certificates expired: ${x509Chain}`,
         success: false,
       };
     }
@@ -37,7 +37,7 @@ export const validateIssuance = (
         const parent = x509Chain[index + 1];
         if (!cert || !parent || !cert.verify(parent.publicKey)) {
           return {
-            reason: "Certificates chain is invalid",
+            reason: `Certificates chain is invalid: ${x509Chain}`,
             success: false,
           };
         }
@@ -49,7 +49,7 @@ export const validateIssuance = (
   const rootCert = x509Chain[x509Chain.length - 1]; // Last certificate in the chain is the root certificate
   if (!rootCert || !rootCert.verify(rootPublicKey)) {
     return {
-      reason: `Root certificate is not signed by root public key provided: ${rootCert.serialNumber}`,
+      reason: `Root certificate is not signed by root public key provided: ${x509Chain}`,
       success: false,
     };
   }

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -77,7 +77,7 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
               revokeUserValidWalletInstancesExceptOne(
                 walletInstanceRequest.fiscalCode,
                 walletInstanceRequest.hardwareKeyTag,
-                RevocationReason.newWalletInstanceCreated,
+                RevocationReason.NewWalletInstanceCreated,
               ),
             ),
           ),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -19,6 +19,7 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
+import { RevocationReason } from "io-wallet-common/wallet-instance";
 
 const WalletInstanceRequestPayload = t.type({
   challenge: NonEmptyString,
@@ -76,6 +77,7 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
               revokeUserValidWalletInstancesExceptOne(
                 walletInstanceRequest.fiscalCode,
                 walletInstanceRequest.hardwareKeyTag,
+                RevocationReason.newWalletInstanceCreated,
               ),
             ),
           ),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance.ts
@@ -19,7 +19,6 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import * as TE from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
-import { RevocationReason } from "io-wallet-common/wallet-instance";
 
 const WalletInstanceRequestPayload = t.type({
   challenge: NonEmptyString,
@@ -77,7 +76,7 @@ export const CreateWalletInstanceHandler = H.of((req: H.HttpRequest) =>
               revokeUserValidWalletInstancesExceptOne(
                 walletInstanceRequest.fiscalCode,
                 walletInstanceRequest.hardwareKeyTag,
-                RevocationReason.NewWalletInstanceCreated,
+                "NEW_WALLET_INSTANCE_CREATED",
               ),
             ),
           ),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
@@ -40,11 +40,7 @@ const revokeCurrentUserWalletInstance: (
     fiscalCode,
     getCurrentWalletInstance,
     RTE.chainW(({ id, userId }) =>
-      revokeUserWalletInstances(
-        userId,
-        [id],
-        RevocationReason.revokedThroughAppIo,
-      ),
+      revokeUserWalletInstances(userId, [id], RevocationReason.revokedByUser),
     ),
   );
 

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
@@ -12,6 +12,7 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
+import { RevocationReason } from "io-wallet-common/wallet-instance";
 
 const SetCurrentWalletInstanceStatusBody = t.type({
   fiscal_code: FiscalCode,
@@ -38,7 +39,13 @@ const revokeCurrentUserWalletInstance: (
   pipe(
     fiscalCode,
     getCurrentWalletInstance,
-    RTE.chainW(({ id, userId }) => revokeUserWalletInstances(userId, [id])),
+    RTE.chainW(({ id, userId }) =>
+      revokeUserWalletInstances(
+        userId,
+        [id],
+        RevocationReason.revokedThroughAppIo,
+      ),
+    ),
   );
 
 export const SetCurrentWalletInstanceStatusHandler = H.of(

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
@@ -12,7 +12,6 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
-import { RevocationReason } from "io-wallet-common/wallet-instance";
 
 const SetCurrentWalletInstanceStatusBody = t.type({
   fiscal_code: FiscalCode,
@@ -40,7 +39,7 @@ const revokeCurrentUserWalletInstance: (
     fiscalCode,
     getCurrentWalletInstance,
     RTE.chainW(({ id, userId }) =>
-      revokeUserWalletInstances(userId, [id], RevocationReason.RevokedByUser),
+      revokeUserWalletInstances(userId, [id], "REVOKED_BY_USER"),
     ),
   );
 

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-current-wallet-instance-status.ts
@@ -40,7 +40,7 @@ const revokeCurrentUserWalletInstance: (
     fiscalCode,
     getCurrentWalletInstance,
     RTE.chainW(({ id, userId }) =>
-      revokeUserWalletInstances(userId, [id], RevocationReason.revokedByUser),
+      revokeUserWalletInstances(userId, [id], RevocationReason.RevokedByUser),
     ),
   );
 

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
@@ -54,7 +54,7 @@ export const SetWalletInstanceStatusHandler = H.of((req: H.HttpRequest) =>
           revokeUserWalletInstances(
             fiscalCode,
             [walletInstanceId],
-            RevocationReason.revokedByUser,
+            RevocationReason.RevokedByUser,
           ),
         ),
         RTE.orElseFirstW((error) =>

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
@@ -10,7 +10,6 @@ import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { sendTelemetryException } from "io-wallet-common/infra/azure/appinsights/telemetry";
 import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
-import { RevocationReason } from "io-wallet-common/wallet-instance";
 
 const requireWalletInstanceId: (
   req: H.HttpRequest,
@@ -54,7 +53,7 @@ export const SetWalletInstanceStatusHandler = H.of((req: H.HttpRequest) =>
           revokeUserWalletInstances(
             fiscalCode,
             [walletInstanceId],
-            RevocationReason.RevokedByUser,
+            "REVOKED_BY_USER",
           ),
         ),
         RTE.orElseFirstW((error) =>

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
@@ -10,6 +10,7 @@ import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { sendTelemetryException } from "io-wallet-common/infra/azure/appinsights/telemetry";
 import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
+import { RevocationReason } from "io-wallet-common/wallet-instance";
 
 const requireWalletInstanceId: (
   req: H.HttpRequest,
@@ -50,7 +51,11 @@ export const SetWalletInstanceStatusHandler = H.of((req: H.HttpRequest) =>
         revokeAllCredentials(fiscalCode),
         RTE.chainW(() =>
           // access our database to revoke the wallet instance
-          revokeUserWalletInstances(fiscalCode, [walletInstanceId]),
+          revokeUserWalletInstances(
+            fiscalCode,
+            [walletInstanceId],
+            RevocationReason.revokedThroughIoWeb,
+          ),
         ),
         RTE.orElseFirstW((error) =>
           pipe(

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instance-status.ts
@@ -54,7 +54,7 @@ export const SetWalletInstanceStatusHandler = H.of((req: H.HttpRequest) =>
           revokeUserWalletInstances(
             fiscalCode,
             [walletInstanceId],
-            RevocationReason.revokedThroughIoWeb,
+            RevocationReason.revokedByUser,
           ),
         ),
         RTE.orElseFirstW((error) =>

--- a/apps/io-wallet-user-func/src/wallet-instance-revocation-process.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance-revocation-process.ts
@@ -64,14 +64,14 @@ const validateWalletInstanceCertificatesChain =
                       ? { success: true }
                       : {
                           certificatesRevocationReason:
-                            RevocationReason.certificateRevoked as RevocationReason,
+                            RevocationReason.CertificateRevoked as RevocationReason,
                           success: false,
                         },
                   ),
                 )
               : TE.right({
                   certificatesRevocationReason:
-                    RevocationReason.certificateExpiredOrInvalid as RevocationReason,
+                    RevocationReason.CertificateExpiredOrInvalid as RevocationReason,
                   success: false,
                 }),
           ),

--- a/apps/io-wallet-user-func/src/wallet-instance-revocation-process.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance-revocation-process.ts
@@ -64,14 +64,14 @@ const validateWalletInstanceCertificatesChain =
                       ? { success: true }
                       : {
                           certificatesRevocationReason:
-                            RevocationReason.CertificateRevoked as RevocationReason,
+                            "CERTIFICATE_REVOKED_BY_ISSUER" as RevocationReason,
                           success: false,
                         },
                   ),
                 )
               : TE.right({
                   certificatesRevocationReason:
-                    RevocationReason.CertificateExpiredOrInvalid as RevocationReason,
+                    "CERTIFICATE_EXPIRED_OR_INVALID" as RevocationReason,
                   success: false,
                 }),
           ),

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -27,12 +27,13 @@ export const WalletInstanceValid = t.intersection([
 
 export type WalletInstanceValid = t.TypeOf<typeof WalletInstanceValid>;
 
-export enum RevocationReason {
-  CertificateExpiredOrInvalid = "CERTIFICATE_EXPIRED_OR_INVALID",
-  CertificateRevoked = "CERTIFICATE_REVOKED_BY_ISSUER",
-  NewWalletInstanceCreated = "NEW_WALLET_INSTANCE_CREATED",
-  RevokedByUser = "REVOKED_BY_USER",
-}
+export const RevocationReason = t.union([
+  t.literal("CERTIFICATE_EXPIRED_OR_INVALID"),
+  t.literal("CERTIFICATE_REVOKED_BY_ISSUER"),
+  t.literal("NEW_WALLET_INSTANCE_CREATED"),
+  t.literal("REVOKED_BY_USER"),
+]);
+export type RevocationReason = t.TypeOf<typeof RevocationReason>;
 
 const WalletInstanceRevoked = t.intersection([
   WalletInstanceBase,
@@ -41,7 +42,7 @@ const WalletInstanceRevoked = t.intersection([
     revokedAt: IsoDateFromString,
   }),
   t.partial({
-    revocationReason: t.keyof(RevocationReason),
+    revocationReason: RevocationReason,
   }),
 ]);
 

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -28,10 +28,10 @@ export const WalletInstanceValid = t.intersection([
 export type WalletInstanceValid = t.TypeOf<typeof WalletInstanceValid>;
 
 export enum RevocationReason {
-  certificateExpiredOrInvalid = "CERTIFICATE_EXPIRED_OR_INVALID",
-  certificateRevoked = "CERTIFICATE_REVOKED_BY_ISSUER",
-  newWalletInstanceCreated = "NEW_WALLET_INSTANCE_CREATED",
-  revokedByUser = "REVOKED_BY_USER",
+  CertificateExpiredOrInvalid = "CERTIFICATE_EXPIRED_OR_INVALID",
+  CertificateRevoked = "CERTIFICATE_REVOKED_BY_ISSUER",
+  NewWalletInstanceCreated = "NEW_WALLET_INSTANCE_CREATED",
+  RevokedByUser = "REVOKED_BY_USER",
 }
 
 const WalletInstanceRevoked = t.intersection([

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -27,11 +27,22 @@ export const WalletInstanceValid = t.intersection([
 
 export type WalletInstanceValid = t.TypeOf<typeof WalletInstanceValid>;
 
+export enum RevocationReason {
+  certificateExpiredOrInvalid = "CERTIFICATE_EXPIRED_OR_INVALID",
+  certificateRevoked = "CERTIFICATE_REVOKED_BY_ISSUER",
+  newWalletInstanceCreated = "NEW_WALLET_INSTANCE_CREATED",
+  revokedThroughAppIo = "REVOKED_THROUGH_APP_IO",
+  revokedThroughIoWeb = "REVOKED_THROUGH_IO_WEB",
+}
+
 const WalletInstanceRevoked = t.intersection([
   WalletInstanceBase,
   t.type({
     isRevoked: t.literal(true),
     revokedAt: IsoDateFromString,
+  }),
+  t.partial({
+    revocationReason: t.keyof(RevocationReason),
   }),
 ]);
 

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -31,8 +31,7 @@ export enum RevocationReason {
   certificateExpiredOrInvalid = "CERTIFICATE_EXPIRED_OR_INVALID",
   certificateRevoked = "CERTIFICATE_REVOKED_BY_ISSUER",
   newWalletInstanceCreated = "NEW_WALLET_INSTANCE_CREATED",
-  revokedThroughAppIo = "REVOKED_THROUGH_APP_IO",
-  revokedThroughIoWeb = "REVOKED_THROUGH_IO_WEB",
+  revokedByUser = "REVOKED_BY_USER",
 }
 
 const WalletInstanceRevoked = t.intersection([

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -28,7 +28,6 @@ export const WalletInstanceValid = t.intersection([
 export type WalletInstanceValid = t.TypeOf<typeof WalletInstanceValid>;
 
 export const RevocationReason = t.union([
-  t.literal("CERTIFICATE_EXPIRED_OR_INVALID"),
   t.literal("CERTIFICATE_REVOKED_BY_ISSUER"),
   t.literal("NEW_WALLET_INSTANCE_CREATED"),
   t.literal("REVOKED_BY_USER"),


### PR DESCRIPTION
Add `revocationReason` param to `RevokedWalletInstance`. This does not impact openapi for now.
Remove also expiration check on Wallet Instance Certificates