### PR TITLE
[CES-556] Replicate queue storage to process Cosmos 02 change feed

### DIFF
--- a/infra/resources/_modules/storage_accounts/README.md
+++ b/infra/resources/_modules/storage_accounts/README.md
@@ -23,6 +23,7 @@ No requirements.
 |------|------|
 | [azurerm_key_vault_secret.st_connection_string](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret) | resource |
 | [azurerm_storage_queue.wallet_instances_revocation_check](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_storage_queue.wallet_instances_revocation_check_02](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
 
 ## Inputs
 
@@ -46,5 +47,6 @@ No requirements.
 | Name | Description |
 |------|-------------|
 | <a name="output_revocation_queue_name"></a> [revocation\_queue\_name](#output\_revocation\_queue\_name) | n/a |
+| <a name="output_revocation_queue_name_02"></a> [revocation\_queue\_name\_02](#output\_revocation\_queue\_name\_02) | n/a |
 | <a name="output_wallet"></a> [wallet](#output\_wallet) | n/a |
 <!-- END_TF_DOCS -->

--- a/infra/resources/_modules/storage_accounts/outputs.tf
+++ b/infra/resources/_modules/storage_accounts/outputs.tf
@@ -4,6 +4,12 @@ output "revocation_queue_name" {
   }
 }
 
+output "revocation_queue_name_02" {
+  value = {
+    name = azurerm_storage_queue.wallet_instances_revocation_check_02.name
+  }
+}
+
 output "wallet" {
   value = {
     id                            = module.storage_account.id

--- a/infra/resources/_modules/storage_accounts/storage_queue.tf
+++ b/infra/resources/_modules/storage_accounts/storage_queue.tf
@@ -2,3 +2,8 @@ resource "azurerm_storage_queue" "wallet_instances_revocation_check" {
   name                 = "wallet-instances-revocation-check"
   storage_account_name = module.storage_account.name
 }
+
+resource "azurerm_storage_queue" "wallet_instances_revocation_check_02" {
+  name                 = "wallet-instances-revocation-check-02"
+  storage_account_name = module.storage_account.name
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

Creates a new queue to process Cosmos 02 change feed

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

A new change feed is necessary due to migration and having two queues at the same time is preferable to preserve data integrity

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
