### PR TITLE
[SIW-1560] Add queue triggered function for email sender

### DIFF
--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -261,7 +261,7 @@ app.storageQueue("callPidIssuerRevokeApi", {
     config.azure.storage.walletInstances.queues.pidIssuerRevokeApi.name,
 });
 
-app.storageQueue("sendEmailOnWalletInstanceCreationQueue", {
+app.storageQueue("sendEmailOnWalletInstanceCreation", {
   connection: "StorageConnectionString",
   handler: SendEmailOnWalletInstanceCreationFunction({
     emailNotificationService,

--- a/apps/io-wallet-user-func/src/infra/azure/storage/wallet-instance-revocation.ts
+++ b/apps/io-wallet-user-func/src/infra/azure/storage/wallet-instance-revocation.ts
@@ -1,15 +1,10 @@
+import { IWalletInstanceRevocationStorageQueue } from "@/wallet-instance-revocation-process";
 import { QueueClient } from "@azure/storage-queue";
 import * as E from "fp-ts/lib/Either";
 import * as J from "fp-ts/lib/Json";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/function";
 import { WalletInstanceValidWithAndroidCertificatesChain } from "io-wallet-common/wallet-instance";
-
-export interface IWalletInstanceRevocationStorageQueue {
-  insert: (
-    walletInstance: WalletInstanceValidWithAndroidCertificatesChain,
-  ) => TE.TaskEither<Error, void>;
-}
 
 export class WalletInstanceRevocationStorageQueue
   implements IWalletInstanceRevocationStorageQueue

--- a/apps/io-wallet-user-func/src/infra/handlers/send-email-on-wallet-instance-creation.ts
+++ b/apps/io-wallet-user-func/src/infra/handlers/send-email-on-wallet-instance-creation.ts
@@ -14,10 +14,10 @@ import * as RTE from "fp-ts/lib/ReaderTaskEither";
 import { EmailNotificationService } from "../email-notification-service";
 
 // [SIW-1560] to do - a mock function that return the user email by the fiscal code
-const getUserInfoByFiscalCode = (
+const getUserEmailByFiscalCode = (
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   fiscalCode: string,
-): RTE.ReaderTaskEither<object, Error, { email: string; firstName: string }> =>
+): RTE.ReaderTaskEither<object, Error, string> =>
   RTE.left(new Error("Not implemented yet"));
 
 export const sendEmailToUser: (
@@ -34,17 +34,16 @@ export const sendEmailToUser: (
 export const SendEmailOnWalletInstanceCreationHandler = H.of(
   (fiscalCode: FiscalCode) =>
     pipe(
-      getUserInfoByFiscalCode(fiscalCode),
-      RTE.chainW(({ email, firstName }) =>
+      getUserEmailByFiscalCode(fiscalCode),
+      RTE.chainW((emailAddress) =>
         sendEmailToUser({
           html: WalletInstanceActivationEmailTemplate(
-            firstName,
             WALLET_ACTIVATION_EMAIL_FAQ_LINK,
             WALLET_ACTIVATION_EMAIL_HANDLE_ACCESS_LINK,
           ),
           subject: WALLET_ACTIVATION_EMAIL_SUBJECT,
           text: WALLET_ACTIVATION_EMAIL_TEXT,
-          to: email,
+          to: emailAddress,
         }),
       ),
     ),

--- a/apps/io-wallet-user-func/src/templates/wallet-instance-activation/index.html.ts
+++ b/apps/io-wallet-user-func/src/templates/wallet-instance-activation/index.html.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line max-lines-per-function
-export default (firstName: string, faqLink: string, ioAppLink: string) => `
+export default (faqLink: string, ioAppLink: string) => `
 <!doctype html>
 <html lang="it" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
 
@@ -324,7 +324,7 @@ export default (firstName: string, faqLink: string, ioAppLink: string) => `
                               <tr>
                                 <td align="left" class="text" style="font-size:0px;padding:10px 25px;padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;word-break:break-word;">
                                   <div style="font-family:Titillium Web, system-ui, sans-serif;font-size:16px;font-weight:regular;line-height:24px;text-align:left;color:#17324D;">
-                                    <p> Ciao ${firstName},<br /><br /> il tuo portafoglio sull'app IO è pronto a <strong>ricevere la versione digitale dei<br /> tuoi documenti</strong> personali! </p>
+                                    <p> Ciao,<br /><br /> il tuo portafoglio sull'app IO è pronto a <strong>ricevere la versione digitale dei<br /> tuoi documenti</strong> personali! </p>
                                     <p>
                                       <strong>Attiva Documenti su IO</strong>
                                     </p>

--- a/apps/io-wallet-user-func/src/wallet-instance-revocation-process.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance-revocation-process.ts
@@ -128,3 +128,9 @@ export const revokeInvalidWalletInstances: (
             revocationQueue.insert(walletInstance),
       ),
     );
+
+export interface IWalletInstanceRevocationStorageQueue {
+  insert: (
+    walletInstance: WalletInstanceValidWithAndroidCertificatesChain,
+  ) => TE.TaskEither<Error, void>;
+}

--- a/infra/resources/_modules/function_apps/locals.tf
+++ b/infra/resources/_modules/function_apps/locals.tf
@@ -54,7 +54,7 @@ locals {
     "validateWalletInstance",
     "generateEntityConfiguration",
     "callPidIssuerRevokeApi",
-    "sendEmailOnWalletInstanceCreationQueue",
+    "sendEmailOnWalletInstanceCreation",
   ]
 
   function_app_user = {


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

**DISCLAIMER**
The code of this PR isn't ready for a production environment, because the `getUserInfoByFiscalCode()` function has a to do (it isn't implemented).

#### List of Changes

<!--- Describe your changes in detail -->

What did I do?
I created a storage queue handler that send an email to a specific user when a wallet instance has been created. This PR is based on [this PR](https://github.com/pagopa/io-wallet/pull/322).

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The change is necessary because the user who created and activated a new wallet instance must be able to receive an email confirming it and advising that it can be revoked at any time.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
