### PR TITLE
[#IOPID-2542] Allow 'account.ioapp.it' subdomain

### DIFF
--- a/infra/resources/_modules/apim/api/ioweb/_base_policy.xml
+++ b/infra/resources/_modules/apim/api/ioweb/_base_policy.xml
@@ -4,6 +4,7 @@
         <cors>
             <allowed-origins>
                 <origin>https://ioapp.it/</origin>
+                <origin>https://account.ioapp.it/</origin>
             </allowed-origins>
             <allowed-methods preflight-result-max-age="300">
                 <method>OPTIONS</method>


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- Add `https://account.ioapp.it` as allowed origin

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

#[IOPID-2392](https://pagopa.atlassian.net/browse/IOPID-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ): Migrate `ioapp.it` to subdomain `account.ioapp.it`

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
NA


#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.


[IOPID-2392]: https://pagopa.atlassian.net/browse/IOPID-2392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ