### PR TITLE
fix: [SIW-2920] Updated wallet instance schema

### DIFF
--- a/.changeset/curly-birds-eat.md
+++ b/.changeset/curly-birds-eat.md
@@ -1,0 +1,7 @@
+---
+"io-wallet-support-func": patch
+"io-wallet-common": patch
+"io-wallet-user-func": patch
+---
+
+Strengthened data validation in createWalletInstance and updated WalletInstance schema to allow string osPatchLevel for revoked instances

--- a/apps/io-wallet-support-func/host.json
+++ b/apps/io-wallet-support-func/host.json
@@ -11,7 +11,7 @@
   },
   "logging": {
     "logLevel": {
-      "default": "Error",
+      "default": "Warning",
       "Host.Aggregator": "Information",
       "Host.Results": "Information"
     }

--- a/apps/io-wallet-support-func/openapi.yaml
+++ b/apps/io-wallet-support-func/openapi.yaml
@@ -178,7 +178,9 @@ components:
           type: string
           enum: ["android"]
         os_patch_level:
-          type: number
+          oneOf:
+            - type: string
+            - type: number
         os_version:
           type: number
       required:

--- a/apps/io-wallet-support-func/src/infra/http/encoders/wallet-instance.ts
+++ b/apps/io-wallet-support-func/src/infra/http/encoders/wallet-instance.ts
@@ -3,6 +3,7 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 import {
   AndroidDeviceDetails,
+  AndroidDeviceDetailsRevokedWI,
   IosDeviceDetails,
 } from "io-wallet-common/device-details";
 import {
@@ -14,6 +15,9 @@ const androidDevicePlatform = AndroidDeviceDetails.types[0].props.platform;
 
 const androidDeviceOptionalFields = AndroidDeviceDetails.types[1].props;
 
+const androidDeviceRevokedWIOptionalFields =
+  AndroidDeviceDetailsRevokedWI.types[1].props;
+
 const DeviceDetails = t.union([
   IosDeviceDetails,
   t.intersection([
@@ -21,7 +25,10 @@ const DeviceDetails = t.union([
       platform: androidDevicePlatform,
     }),
     t.partial({
-      os_patch_level: androidDeviceOptionalFields.osPatchLevel,
+      os_patch_level: t.union([
+        androidDeviceOptionalFields.osPatchLevel,
+        androidDeviceRevokedWIOptionalFields.osPatchLevel,
+      ]),
       os_version: androidDeviceOptionalFields.osVersion,
     }),
   ]),

--- a/apps/io-wallet-support-func/src/infra/http/encoders/wallet-instance.ts
+++ b/apps/io-wallet-support-func/src/infra/http/encoders/wallet-instance.ts
@@ -3,7 +3,7 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 import {
   AndroidDeviceDetails,
-  AndroidDeviceDetailsRevokedWI,
+  AndroidDeviceDetailsStringOsPatchLevel,
   IosDeviceDetails,
 } from "io-wallet-common/device-details";
 import {
@@ -13,10 +13,10 @@ import {
 
 const androidDevicePlatform = AndroidDeviceDetails.types[0].props.platform;
 
-const androidDeviceOptionalFields = AndroidDeviceDetails.types[1].props;
+const androidDeviceFields = AndroidDeviceDetails.types[1].props;
 
-const androidDeviceRevokedWIOptionalFields =
-  AndroidDeviceDetailsRevokedWI.types[1].props;
+const androidDeviceStringOsPatchLevelFields =
+  AndroidDeviceDetailsStringOsPatchLevel.types[1].props;
 
 const DeviceDetails = t.union([
   IosDeviceDetails,
@@ -26,10 +26,10 @@ const DeviceDetails = t.union([
     }),
     t.partial({
       os_patch_level: t.union([
-        androidDeviceOptionalFields.osPatchLevel,
-        androidDeviceRevokedWIOptionalFields.osPatchLevel,
+        androidDeviceFields.osPatchLevel,
+        androidDeviceStringOsPatchLevelFields.osPatchLevel,
       ]),
-      os_version: androidDeviceOptionalFields.osVersion,
+      os_version: androidDeviceFields.osVersion,
     }),
   ]),
 ]);

--- a/apps/io-wallet-user-func/host.json
+++ b/apps/io-wallet-user-func/host.json
@@ -16,11 +16,9 @@
   },
   "logging": {
     "logLevel": {
-      "default": "Error",
+      "default": "Warning",
       "Host.Aggregator": "Information",
-      "Host.Results": "Information",
-      "Microsoft": "Information",
-      "Function.HttpTrigger": "Error"
+      "Host.Results": "Information"
     }
   }
 }

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/create-wallet-instance.spec.ts
@@ -9,13 +9,13 @@ import * as TE from "fp-ts/TaskEither";
 import { describe, expect, it, vi } from "vitest";
 
 import { AttestationService } from "@/attestation-service";
+import { IntegrityCheckError } from "@/infra/mobile-attestation-service";
 import { iOSMockData } from "@/infra/mobile-attestation-service/ios/__test__/config";
 import { NonceRepository } from "@/nonce";
 import { WalletInstanceRepository } from "@/wallet-instance";
 import { WhitelistedFiscalCodeRepository } from "@/whitelisted-fiscal-code";
 
 import { CreateWalletInstanceHandler } from "../create-wallet-instance";
-import { IntegrityCheckError } from "@/infra/mobile-attestation-service";
 
 const mockFiscalCode = "AAACCC94E17H501P" as FiscalCode;
 

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-current-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__test__/get-current-wallet-instance-status.spec.ts
@@ -216,4 +216,59 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
       }),
     });
   });
+
+  it("should return a 200 HTTP response on success with revoked wallet instance with string os_patch_level in device_details", async () => {
+    const mockDate = new Date();
+    walletInstanceRepository.getLastByUserId = () =>
+      TE.right(
+        O.some({
+          createdAt: mockDate,
+          deviceDetails: {
+            attestationSecurityLevel: 1,
+            attestationVersion: 4,
+            deviceLocked: true,
+            keymasterSecurityLevel: 1,
+            keymasterVersion: 41,
+            osPatchLevel: "20250805",
+            osVersion: 140000,
+            platform: "android",
+            verifiedBootState: 0,
+            x509Chain: ["a"],
+          },
+          hardwareKey: {
+            crv: "P-256",
+            kty: "EC",
+            x: "z3PTdkV20dwTADp2Xur5AXqLbQz7stUbvRNghMQu1rY",
+            y: "Z7MC2EHmlPuoYDRVfy-upr_06-lBYobEk_TCwuSb2ho",
+          },
+          id: "123" as NonEmptyString,
+          isRevoked: true,
+          revocationReason: "CERTIFICATE_REVOKED_BY_ISSUER",
+          revokedAt: mockDate,
+          signCount: 0,
+          userId: "AAACCCZ55H501P" as FiscalCode,
+        }),
+      );
+    const handler = GetCurrentWalletInstanceStatusHandler({
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: {
+        body: {
+          id: "123",
+          is_revoked: true,
+          revocation_reason: "CERTIFICATE_REVOKED_BY_ISSUER",
+        },
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+        statusCode: 200,
+      },
+    });
+  });
 });

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/index.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/index.ts
@@ -1,4 +1,4 @@
-import { parse } from "@pagopa/handler-kit";
+import { parse, ValidationError } from "@pagopa/handler-kit";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { X509Certificate } from "crypto";
 import * as E from "fp-ts/Either";
@@ -7,6 +7,8 @@ import * as J from "fp-ts/Json";
 import * as RA from "fp-ts/lib/ReadonlyArray";
 import * as S from "fp-ts/lib/string";
 import * as TE from "fp-ts/TaskEither";
+import * as t from "io-ts";
+import { AndroidDeviceDetails } from "io-wallet-common/device-details";
 import { JwkPublicKey } from "io-wallet-common/jwk";
 
 import { getCrlFromUrls } from "@/certificates";
@@ -19,6 +21,11 @@ import { verifyAttestation } from "./attestation";
 export const base64ToPem = (b64cert: string) =>
   `-----BEGIN CERTIFICATE-----\n${b64cert}-----END CERTIFICATE-----`;
 
+const DeviceDetailsWithKey = t.type({
+  deviceDetails: AndroidDeviceDetails,
+  hardwareKey: JwkPublicKey,
+});
+
 // TODO: [SIW-944] Add Android integrity check. This is a mock
 export const validateAndroidAttestation = (
   data: Buffer,
@@ -28,7 +35,7 @@ export const validateAndroidAttestation = (
   googlePublicKey: string,
   androidCrlUrls: string[],
   httpRequestTimeout: number,
-): TE.TaskEither<Error, ValidatedAttestation> =>
+): TE.TaskEither<Error | ValidationError, ValidatedAttestation> =>
   pipe(
     data.toString("utf-8"),
     S.split(","),
@@ -66,14 +73,7 @@ export const validateAndroidAttestation = (
                 new AndroidAttestationError(attestationValidationResult.reason),
               ),
         ),
-        TE.chainW(({ deviceDetails, hardwareKey }) =>
-          pipe(
-            hardwareKey,
-            parse(JwkPublicKey, "Invalid JWK Public Key"),
-            E.map((hardwareKey) => ({ deviceDetails, hardwareKey })),
-            TE.fromEither,
-          ),
-        ),
+        TE.chainW(flow(parse(DeviceDetailsWithKey), TE.fromEither)),
       ),
     ),
   );

--- a/packages/io-wallet-common/src/device-details.ts
+++ b/packages/io-wallet-common/src/device-details.ts
@@ -31,7 +31,7 @@ export const DeviceDetails = t.union([AndroidDeviceDetails, IosDeviceDetails]);
 
 export type DeviceDetails = t.TypeOf<typeof DeviceDetails>;
 
-const AndroidDeviceDetailsStringOsPatchLevel = t.intersection([
+export const AndroidDeviceDetailsStringOsPatchLevel = t.intersection([
   t.type({
     attestationSecurityLevel: t.number,
     attestationVersion: t.number,

--- a/packages/io-wallet-common/src/device-details.ts
+++ b/packages/io-wallet-common/src/device-details.ts
@@ -30,3 +30,29 @@ export type AndroidDeviceDetails = t.TypeOf<typeof AndroidDeviceDetails>;
 export const DeviceDetails = t.union([AndroidDeviceDetails, IosDeviceDetails]);
 
 export type DeviceDetails = t.TypeOf<typeof DeviceDetails>;
+
+// Some revoked wallet instances in the database have `osPatchLevel` stored as a string,
+// so we allow `osPatchLevel` to be either a number or a string for revoked instances only
+export const AndroidDeviceDetailsRevokedWI = t.intersection([
+  t.type({
+    attestationSecurityLevel: t.number,
+    attestationVersion: t.number,
+    keymasterSecurityLevel: t.number,
+    keymasterVersion: t.number,
+    platform: t.literal("android"),
+  }),
+  t.partial({
+    bootPatchLevel: t.string,
+    deviceLocked: t.boolean,
+    osPatchLevel: t.union([t.number, t.string]),
+    osVersion: t.number,
+    vendorPatchLevel: t.string,
+    verifiedBootState: t.number,
+    x509Chain: t.array(t.string),
+  }),
+]);
+
+export const DeviceDetailsRevokedWI = t.union([
+  AndroidDeviceDetailsRevokedWI,
+  IosDeviceDetails,
+]);

--- a/packages/io-wallet-common/src/device-details.ts
+++ b/packages/io-wallet-common/src/device-details.ts
@@ -31,9 +31,7 @@ export const DeviceDetails = t.union([AndroidDeviceDetails, IosDeviceDetails]);
 
 export type DeviceDetails = t.TypeOf<typeof DeviceDetails>;
 
-// Some revoked wallet instances in the database have `osPatchLevel` stored as a string,
-// so we allow `osPatchLevel` to be either a number or a string for revoked instances only
-export const AndroidDeviceDetailsRevokedWI = t.intersection([
+const AndroidDeviceDetailsStringOsPatchLevel = t.intersection([
   t.type({
     attestationSecurityLevel: t.number,
     attestationVersion: t.number,
@@ -52,7 +50,7 @@ export const AndroidDeviceDetailsRevokedWI = t.intersection([
   }),
 ]);
 
-export const DeviceDetailsRevokedWI = t.union([
-  AndroidDeviceDetailsRevokedWI,
+export const DeviceDetailsStringOsPatchLevel = t.union([
+  AndroidDeviceDetailsStringOsPatchLevel,
   IosDeviceDetails,
 ]);

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -2,26 +2,28 @@ import { IsoDateFromString } from "@pagopa/ts-commons/lib/dates";
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as t from "io-ts";
 
-import { AndroidDeviceDetails, DeviceDetails } from "./device-details";
+import {
+  AndroidDeviceDetails,
+  DeviceDetails,
+  DeviceDetailsRevokedWI,
+} from "./device-details";
 import { JwkPublicKey } from "./jwk";
 
-const WalletInstanceBase = t.intersection([
-  t.type({
-    createdAt: IsoDateFromString,
-    hardwareKey: JwkPublicKey,
-    id: NonEmptyString,
-    signCount: t.number,
-    userId: FiscalCode,
-  }),
-  t.partial({
-    deviceDetails: DeviceDetails,
-  }),
-]);
+const WalletInstanceBase = t.type({
+  createdAt: IsoDateFromString,
+  hardwareKey: JwkPublicKey,
+  id: NonEmptyString,
+  signCount: t.number,
+  userId: FiscalCode,
+});
 
 export const WalletInstanceValid = t.intersection([
   WalletInstanceBase,
   t.type({
     isRevoked: t.literal(false),
+  }),
+  t.partial({
+    deviceDetails: DeviceDetails,
   }),
 ]);
 
@@ -41,6 +43,7 @@ const WalletInstanceRevoked = t.intersection([
     revokedAt: IsoDateFromString,
   }),
   t.partial({
+    deviceDetails: DeviceDetailsRevokedWI,
     revocationReason: RevocationReason,
   }),
 ]);

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -5,7 +5,7 @@ import * as t from "io-ts";
 import {
   AndroidDeviceDetails,
   DeviceDetails,
-  DeviceDetailsRevokedWI,
+  DeviceDetailsStringOsPatchLevel,
 } from "./device-details";
 import { JwkPublicKey } from "./jwk";
 
@@ -36,6 +36,8 @@ export const RevocationReason = t.union([
 ]);
 export type RevocationReason = t.TypeOf<typeof RevocationReason>;
 
+// Some revoked wallet instances in the database have `osPatchLevel` stored as a string,
+// so we allow `osPatchLevel` to be either a number or a string for revoked instances only
 const WalletInstanceRevoked = t.intersection([
   WalletInstanceBase,
   t.type({
@@ -43,7 +45,7 @@ const WalletInstanceRevoked = t.intersection([
     revokedAt: IsoDateFromString,
   }),
   t.partial({
-    deviceDetails: DeviceDetailsRevokedWI,
+    deviceDetails: DeviceDetailsStringOsPatchLevel,
     revocationReason: RevocationReason,
   }),
 ]);


### PR DESCRIPTION
**Changes**

1. Added device details data validation in `createWalletInstance`. If validation fails, the endpoint returns a `409` status code.
2. Modified the `WalletInstance` schema: for revoked wallet instances, `osPatchLevel` can now also be a string.

**Why**

There are wallet instances in the database with `osPatchLevel` as a string. These changes were made to: a) Prevent this from happening in the future. b) Avoid validation issues with existing wallet instances that have `osPatchLevel` as a string.