### PR TITLE
fix: updated deploy github workflows

### DIFF
--- a/.github/workflows/support_function_deploy.yaml
+++ b/.github/workflows/support_function_deploy.yaml
@@ -9,13 +9,14 @@ on:
       - "apps/io-wallet-support-func/CHANGELOG.md"
 
 permissions:
+  attestations: write
   id-token: write
   contents: read
 
 jobs:
   deploy:
     name: Deploy
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@main
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@b1d89c1
     secrets: inherit
     with:
       workspace_name: io-wallet-support-func

--- a/.github/workflows/user_function_deploy.yaml
+++ b/.github/workflows/user_function_deploy.yaml
@@ -9,13 +9,14 @@ on:
       - "apps/io-wallet-user-func/CHANGELOG.md"
 
 permissions:
+  attestations: write
   id-token: write
   contents: read
 
 jobs:
   deploy:
     name: Deploy
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@main
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@b1d89c1
     secrets: inherit
     with:
       workspace_name: io-wallet-user-func


### PR DESCRIPTION
List of changes:

- Pins reusable workflow references from `@main` to a specific commit hash `@b1d89c1`
- Adds attestations: write permission to both deployment workflows