### PR TITLE
infra: migrate log alerts to v2 and split prod/UAT rules

### DIFF
--- a/infra/resources/_modules/function_apps/outputs.tf
+++ b/infra/resources/_modules/function_apps/outputs.tf
@@ -25,6 +25,7 @@ output "function_app_support" {
 
 output "function_app_user_uat" {
   value = {
+    name                 = module.function_app_user_uat.function_app.function_app.name
     principal_id         = module.function_app_user_uat.function_app.function_app.principal_id
     staging_principal_id = module.function_app_user_uat.function_app.function_app.slot.principal_id
     resource_group_name  = module.function_app_user_uat.function_app.resource_group_name

--- a/infra/resources/psn/prod/alerts.tf
+++ b/infra/resources/psn/prod/alerts.tf
@@ -1,124 +1,281 @@
-resource "azurerm_monitor_scheduled_query_rules_alert" "create_wallet_instance_no_open_status_lists" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "create_wallet_instance_no_open_status_lists" {
   name                    = "[${module.function_apps.function_app_user.name}] No OPEN status lists available for allocation"
   location                = local.environment.location
   resource_group_name     = data.azurerm_resource_group.wallet.name
   severity                = 0
   description             = "CreateWalletInstance failed because no OPEN status lists were available for allocation"
   auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
 
   action {
-    action_group = [module.monitoring.action_group_wallet.id]
+    action_groups = [module.monitoring.action_group_wallet.id]
   }
 
-  query = <<-EOT
-    AppExceptions
-    | where Properties["functionName"] == "createWalletInstance"
-    | where OuterMessage == "No OPEN status lists available for allocation"
-    | summarize AggregatedValue = sum(ItemCount)
-    EOT
-
-  data_source_id = data.azurerm_log_analytics_workspace.core.id
-
-  trigger {
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user.name}"
+      | where Properties["functionName"] == "createWalletInstance"
+      | where OuterMessage == "No OPEN status lists available for allocation"
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
     operator  = "GreaterThanOrEqual"
     threshold = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
   }
-
-  frequency   = 5
-  time_window = 10
 
   tags = local.tags
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "status_list_manager_errors" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "create_wallet_instance_no_open_status_lists_uat" {
+  name                    = "[${module.function_apps.function_app_user_uat.name}] No OPEN status lists available for allocation"
+  location                = local.environment.location
+  resource_group_name     = data.azurerm_resource_group.wallet.name
+  severity                = 0
+  description             = "CreateWalletInstance failed because no OPEN status lists were available for allocation"
+  auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
+
+  action {
+    action_groups = [module.monitoring.action_group_wallet.id]
+  }
+
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user_uat.name}"
+      | where Properties["functionName"] == "createWalletInstance"
+      | where OuterMessage == "No OPEN status lists available for allocation"
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "status_list_manager_errors" {
   name                    = "[${module.function_apps.function_app_user.name}] StatusListManager Errors"
   location                = local.environment.location
   resource_group_name     = data.azurerm_resource_group.wallet.name
   severity                = 1
   description             = "StatusListManager emitted one or more errors"
   auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
 
   action {
-    action_group = [module.monitoring.action_group_wallet.id]
+    action_groups = [module.monitoring.action_group_wallet.id]
   }
 
-  query = <<-EOT
-    AppExceptions
-    | where Properties["functionName"] == "statusListManager"
-    | summarize AggregatedValue = sum(ItemCount)
-    EOT
-
-  data_source_id = data.azurerm_log_analytics_workspace.core.id
-
-  trigger {
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user.name}"
+      | where Properties["functionName"] == "statusListManager"
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
     operator  = "GreaterThanOrEqual"
     threshold = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
   }
-
-  frequency   = 5
-  time_window = 10
 
   tags = local.tags
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "status_list_publication_errors" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "status_list_manager_errors_uat" {
+  name                    = "[${module.function_apps.function_app_user_uat.name}] StatusListManager Errors"
+  location                = local.environment.location
+  resource_group_name     = data.azurerm_resource_group.wallet.name
+  severity                = 1
+  description             = "StatusListManager emitted one or more errors"
+  auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
+
+  action {
+    action_groups = [module.monitoring.action_group_wallet.id]
+  }
+
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user_uat.name}"
+      | where Properties["functionName"] == "statusListManager"
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "status_list_publication_errors" {
   name                    = "[${module.function_apps.function_app_user.name}] StatusListPublication Errors"
   location                = local.environment.location
   resource_group_name     = data.azurerm_resource_group.wallet.name
   severity                = 1
   description             = "StatusListPublication emitted one or more errors"
   auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
 
   action {
-    action_group = [module.monitoring.action_group_wallet.id]
+    action_groups = [module.monitoring.action_group_wallet.id]
   }
 
-  query = <<-EOT
-    AppExceptions
-    | where Properties["functionName"] in ("statusListPublicationDispatcher", "statusListPublication")
-    | summarize AggregatedValue = sum(ItemCount)
-    EOT
-
-  data_source_id = data.azurerm_log_analytics_workspace.core.id
-
-  trigger {
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user.name}"
+      | where Properties["functionName"] in ("statusListPublicationDispatcher", "statusListPublication")
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
     operator  = "GreaterThanOrEqual"
     threshold = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
   }
-
-  frequency   = 5
-  time_window = 10
 
   tags = local.tags
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "status_list_publication_monitor_critical_issues" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "status_list_publication_errors_uat" {
+  name                    = "[${module.function_apps.function_app_user_uat.name}] StatusListPublication Errors"
+  location                = local.environment.location
+  resource_group_name     = data.azurerm_resource_group.wallet.name
+  severity                = 1
+  description             = "StatusListPublication emitted one or more errors"
+  auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
+
+  action {
+    action_groups = [module.monitoring.action_group_wallet.id]
+  }
+
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user_uat.name}"
+      | where Properties["functionName"] in ("statusListPublicationDispatcher", "statusListPublication")
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
+
+  tags = local.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "status_list_publication_monitor_critical_issues" {
   name                    = "[${module.function_apps.function_app_user.name}] StatusListPublicationMonitor Critical Issues"
   location                = local.environment.location
   resource_group_name     = data.azurerm_resource_group.wallet.name
   severity                = 1
   description             = "StatusListPublicationMonitor detected CDN or JWT validity issues on published status lists"
   auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
 
   action {
-    action_group = [module.monitoring.action_group_wallet.id]
+    action_groups = [module.monitoring.action_group_wallet.id]
   }
 
-  query = <<-EOT
-    AppExceptions
-    | where Properties["functionName"] == "statusListPublicationMonitor"
-    | summarize AggregatedValue = sum(ItemCount)
-    EOT
-
-  data_source_id = data.azurerm_log_analytics_workspace.core.id
-
-  trigger {
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user.name}"
+      | where Properties["functionName"] == "statusListPublicationMonitor"
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
     operator  = "GreaterThanOrEqual"
     threshold = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
   }
 
-  frequency   = 5
-  time_window = 10
+  tags = local.tags
+}
+
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "status_list_publication_monitor_critical_issues_uat" {
+  name                    = "[${module.function_apps.function_app_user_uat.name}] StatusListPublicationMonitor Critical Issues"
+  location                = local.environment.location
+  resource_group_name     = data.azurerm_resource_group.wallet.name
+  severity                = 1
+  description             = "StatusListPublicationMonitor detected CDN or JWT validity issues on published status lists"
+  auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT10M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
+
+  action {
+    action_groups = [module.monitoring.action_group_wallet.id]
+  }
+
+  criteria {
+    query = <<-EOT
+      AppExceptions
+      | where AppRoleName == "${module.function_apps.function_app_user_uat.name}"
+      | where Properties["functionName"] == "statusListPublicationMonitor"
+      | summarize AggregatedValue = sum(ItemCount)
+      EOT
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
+    operator                = "GreaterThanOrEqual"
+    threshold               = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
+  }
 
   tags = local.tags
 }

--- a/infra/resources/psn/prod/cdn.tf
+++ b/infra/resources/psn/prod/cdn.tf
@@ -246,38 +246,41 @@ resource "azurerm_monitor_metric_alert" "storage_account_low_availability" {
   tags = local.tags
 }
 
-resource "azurerm_monitor_scheduled_query_rules_alert" "cdn_requests_error_alert" {
+resource "azurerm_monitor_scheduled_query_rules_alert_v2" "cdn_requests_error_alert" {
   name                    = "[${module.cdn.name}] Request Errors"
   location                = local.environment.location
   resource_group_name     = data.azurerm_resource_group.wallet.name
   severity                = 0
   description             = "Elevated rate of 4xx and 5xx errors from the CDN"
   auto_mitigation_enabled = true
+  evaluation_frequency    = "PT5M"
+  window_duration         = "PT5M"
+  scopes                  = [data.azurerm_log_analytics_workspace.core.id]
 
   action {
-    action_group = [module.monitoring.action_group_wallet.id]
+    action_groups = [module.monitoring.action_group_wallet.id]
   }
 
-  query = format(<<-EOT
-    AzureDiagnostics
-    | where ResourceId == toupper("%s")
-    | where Category == "AzureCdnAccessLog"
-    | where isReceivedFromClient_b == true
-    | where requestUri_s == "https://wallet.io.pagopa.it:443/.well-known/openid-federation"
-    | where httpStatus_d >= 400
-    | summarize AggregatedValue = count()
-    EOT
-  , module.cdn.id)
-
-  data_source_id = data.azurerm_log_analytics_workspace.core.id
-
-  trigger {
+  criteria {
+    query = format(<<-EOT
+      AzureDiagnostics
+      | where ResourceId == toupper("%s")
+      | where Category == "AzureCdnAccessLog"
+      | where isReceivedFromClient_b == true
+      | where requestUri_s == "https://wallet.io.pagopa.it:443/.well-known/openid-federation"
+      | where httpStatus_d >= 400
+      | summarize AggregatedValue = count()
+      EOT
+    , module.cdn.id)
+    time_aggregation_method = "Total"
+    metric_measure_column   = "AggregatedValue"
     operator  = "GreaterThanOrEqual"
     threshold = 1
+    failing_periods {
+      minimum_failing_periods_to_trigger_alert = 1
+      number_of_evaluation_periods             = 1
+    }
   }
-
-  frequency   = 5
-  time_window = 5
 
   tags = local.tags
 }


### PR DESCRIPTION
Migrate legacy scheduled query alerts to v2 and split prod/UAT log alerts by Function App name so telemetry is monitored separately.