### PR TITLE
feat: [SIW-4453] Add new http endpoint POST /wallet-instances/status

### DIFF
--- a/.changeset/green-badgers-stick.md
+++ b/.changeset/green-badgers-stick.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-user-func": minor
+---
+
+Added new http endpoint POST /wallet-instances/status

--- a/.changeset/polite-books-poke.md
+++ b/.changeset/polite-books-poke.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-common": patch
+---
+
+Added USER_DECEASED to the revocation reasons set

--- a/apps/io-wallet-user-func/openapi.yaml
+++ b/apps/io-wallet-user-func/openapi.yaml
@@ -176,6 +176,29 @@ paths:
         "503":
           $ref: "#/components/responses/ServiceUnavailable"
 
+  /wallet-instances/status:
+    post:
+      summary: Revoke Wallet Instances by fiscal code
+      operationId: setWalletInstancesStatus
+      security:
+        - FunctionsKey: []
+      description: |
+        Revoke all valid Wallet Instances associated with the specified fiscal code.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SetWalletInstancesStatusData"
+      responses:
+        "204":
+          description: Wallet Instances status successfully set
+        "422":
+          $ref: "#/components/responses/UnprocessableContent"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+        "503":
+          $ref: "#/components/responses/ServiceUnavailable"
+
   /certificate-chain:
     post:
       operationId: generateCertificateChain
@@ -377,6 +400,22 @@ components:
         - status
         - fiscal_code
 
+    SetWalletInstancesStatusData:
+      type: object
+      properties:
+        status:
+          type: string
+          enum: ["REVOKED"]
+        fiscal_code:
+          $ref: "#/components/schemas/FiscalCode"
+        revocation_reason:
+          type: string
+          enum: ["USER_DECEASED"]
+      required:
+        - status
+        - fiscal_code
+        - revocation_reason
+
     WalletInstanceData:
       description: |-
         Describes the status of the wallet.
@@ -477,6 +516,7 @@ components:
           "NEW_WALLET_INSTANCE_CREATED",
           "WALLET_INSTANCE_RENEWAL",
           "REVOKED_BY_USER",
+          "USER_DECEASED",
         ]
 
     ProblemJson:
@@ -584,10 +624,10 @@ components:
       required:
         - assertion
         - fiscal_code
-    
+
     WalletInstanceAttestation:
       required:
-      - wallet_instance_attestation
+        - wallet_instance_attestation
       type: object
       properties:
         wallet_instance_attestation:
@@ -611,7 +651,7 @@ components:
 
     WalletUnitAttestation:
       required:
-      - wallet_unit_attestation
+        - wallet_unit_attestation
       type: object
       properties:
         wallet_unit_attestation:

--- a/apps/io-wallet-user-func/openapi.yaml
+++ b/apps/io-wallet-user-func/openapi.yaml
@@ -414,7 +414,7 @@ components:
       required:
         - status
         - fiscal_code
-        - revocation_reason
+        - reason
 
     WalletInstanceData:
       description: |-

--- a/apps/io-wallet-user-func/openapi.yaml
+++ b/apps/io-wallet-user-func/openapi.yaml
@@ -408,7 +408,7 @@ components:
           enum: ["REVOKED"]
         fiscal_code:
           $ref: "#/components/schemas/FiscalCode"
-        revocation_reason:
+        reason:
           type: string
           enum: ["USER_DECEASED"]
       required:

--- a/apps/io-wallet-user-func/openapi.yaml
+++ b/apps/io-wallet-user-func/openapi.yaml
@@ -185,6 +185,7 @@ paths:
       description: |
         Revoke all valid Wallet Instances associated with the specified fiscal code.
       requestBody:
+        required: true
         content:
           application/json:
             schema:

--- a/apps/io-wallet-user-func/src/app/main.ts
+++ b/apps/io-wallet-user-func/src/app/main.ts
@@ -39,6 +39,7 @@ import { RevokeWalletInstancesFunction } from "@/infra/azure/functions/revoke-wa
 import { SendEmailOnWalletInstanceCreationFunction } from "@/infra/azure/functions/send-email-on-wallet-instance-creation";
 import { SendEmailOnWalletInstanceRevocationFunction } from "@/infra/azure/functions/send-email-on-wallet-instance-revocation";
 import { SetWalletInstanceStatusFunction } from "@/infra/azure/functions/set-wallet-instance-status";
+import { SetWalletInstancesStatusFunction } from "@/infra/azure/functions/set-wallet-instances-status";
 import { StatusListManagerFunction } from "@/infra/azure/functions/status-list-manager";
 import { StatusListPublicationFunction } from "@/infra/azure/functions/status-list-publication";
 import { StatusListPublicationDispatcherFunction } from "@/infra/azure/functions/status-list-publication-dispatcher";
@@ -352,6 +353,15 @@ app.http("setWalletInstanceStatus", {
   }),
   methods: ["PUT"],
   route: "wallet-instances/{id}/status",
+});
+
+app.http("setWalletInstancesStatus", {
+  authLevel: "function",
+  handler: SetWalletInstancesStatusFunction({
+    walletInstanceRepository,
+  }),
+  methods: ["POST"],
+  route: "wallet-instances/status",
 });
 
 app.storageQueue("sendEmailOnWalletInstanceCreation", {

--- a/apps/io-wallet-user-func/src/infra/azure/cosmos/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/infra/azure/cosmos/wallet-instance.ts
@@ -117,6 +117,48 @@ export class CosmosDbWalletInstanceRepository implements WalletInstanceRepositor
     );
   }
 
+  getValidByUserId(userId: WalletInstance["userId"]) {
+    return pipe(
+      TE.tryCatch(async () => {
+        const { resources: items } = await this.#userIdKeyedContainer.items
+          .query({
+            parameters: [
+              {
+                name: "@partitionKey",
+                value: userId,
+              },
+            ],
+            query:
+              "SELECT * FROM c WHERE c.userId = @partitionKey AND c.isRevoked = false",
+          })
+          .fetchAll();
+        return items;
+      }, toCosmosError("Error getting wallet instances by user id")),
+      TE.chain((items) =>
+        pipe(
+          items,
+          RA.head,
+          O.fold(
+            () => TE.right(O.none),
+            () =>
+              pipe(
+                items,
+                t.array(WalletInstanceValid).decode,
+                E.map(O.some),
+                E.mapLeft(
+                  () =>
+                    new Error(
+                      "Error getting wallet instances: invalid result format",
+                    ),
+                ),
+                TE.fromEither,
+              ),
+          ),
+        ),
+      ),
+    );
+  }
+
   getValidByUserIdExcludingOne(
     walletInstanceId: WalletInstance["id"],
     userId: WalletInstance["userId"],

--- a/apps/io-wallet-user-func/src/infra/azure/functions/set-wallet-instances-status.ts
+++ b/apps/io-wallet-user-func/src/infra/azure/functions/set-wallet-instances-status.ts
@@ -1,0 +1,7 @@
+import { httpAzureFunction } from "@pagopa/handler-kit-azure-func";
+
+import { SetWalletInstancesStatusHandler } from "@/infra/http/handlers/set-wallet-instances-status";
+
+export const SetWalletInstancesStatusFunction = httpAzureFunction(
+  SetWalletInstancesStatusHandler,
+);

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-attestation.spec.ts
@@ -229,6 +229,7 @@ const walletInstanceRepository: WalletInstanceRepository = {
       }),
     ),
   getLastByUserId: () => TE.left(new Error("not implemented")),
+  getValidByUserId: () => TE.left(new Error("not implemented")),
   getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
   insert: () => TE.left(new Error("not implemented")),
 };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-instance-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-instance-attestation.spec.ts
@@ -97,6 +97,7 @@ const walletInstanceRepository: WalletInstanceRepository = {
       }),
     ),
   getLastByUserId: () => TE.left(new Error("not implemented")),
+  getValidByUserId: () => TE.left(new Error("not implemented")),
   getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
   insert: () => TE.left(new Error("not implemented")),
 };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-instance.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-instance.spec.ts
@@ -47,6 +47,7 @@ describe("CreateWalletInstanceHandler", () => {
     batchPatch: () => TE.right(undefined),
     getByUserId: () => TE.left(new Error("not implemented")),
     getLastByUserId: () => TE.left(new Error("not implemented")),
+    getValidByUserId: () => TE.left(new Error("not implemented")),
     getValidByUserIdExcludingOne: () => TE.right(O.some([])),
     insert: insertWalletInstanceSpy,
   };
@@ -270,6 +271,7 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         getByUserId: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
+        getValidByUserId: () => TE.left(new Error("not implemented")),
         getValidByUserIdExcludingOne: () =>
           TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("failed on insert!")),
@@ -485,6 +487,7 @@ describe("CreateWalletInstanceHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       getByUserId: () => TE.left(new Error("not implemented")),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () =>
         TE.left(new Error("failed on getValidByUserIdExcludingOne!")),
       insert: () => TE.left(new Error("not implemented")),
@@ -523,6 +526,7 @@ describe("CreateWalletInstanceHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         getByUserId: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
+        getValidByUserId: () => TE.left(new Error("not implemented")),
         getValidByUserIdExcludingOne: () =>
           TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-unit-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-unit-attestation.spec.ts
@@ -110,6 +110,7 @@ const walletInstanceRepository: WalletInstanceRepository = {
       }),
     ),
   getLastByUserId: () => TE.left(new Error("not implemented")),
+  getValidByUserId: () => TE.left(new Error("not implemented")),
   getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
   insert: () => TE.left(new Error("not implemented")),
 };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/get-current-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/get-current-wallet-instance-status.spec.ts
@@ -36,6 +36,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
           userId: "AAA" as FiscalCode,
         }),
       ),
+    getValidByUserId: () => TE.left(new Error("not implemented")),
     getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
     insert: () => TE.left(new Error("not implemented")),
   };
@@ -130,6 +131,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       getByUserId: () => TE.left(new Error("not implemented")),
       getLastByUserId: () => TE.right(O.none),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -157,6 +159,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         getByUserId: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("failed on getLastByUserId!")),
+        getValidByUserId: () => TE.left(new Error("not implemented")),
         getValidByUserIdExcludingOne: () =>
           TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),
@@ -186,6 +189,7 @@ describe("GetCurrentWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("not implemented")),
         getByUserId: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new ServiceUnavailableError("foo")),
+        getValidByUserId: () => TE.left(new Error("not implemented")),
         getValidByUserIdExcludingOne: () =>
           TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/get-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/get-wallet-instance-status.spec.ts
@@ -68,6 +68,7 @@ describe("GetWalletInstanceStatusHandler", () => {
         }),
       ),
     getLastByUserId: () => TE.left(new Error("not implemented")),
+    getValidByUserId: () => TE.left(new Error("not implemented")),
     getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
     insert: () => TE.left(new Error("not implemented")),
   };
@@ -140,6 +141,7 @@ describe("GetWalletInstanceStatusHandler", () => {
           }),
         ),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -190,6 +192,7 @@ describe("GetWalletInstanceStatusHandler", () => {
           }),
         ),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -255,6 +258,7 @@ describe("GetWalletInstanceStatusHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       getByUserId: () => TE.right(O.none),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -315,6 +319,7 @@ describe("GetWalletInstanceStatusHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       getByUserId: () => TE.left(new Error("failed on get!")),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -343,6 +348,7 @@ describe("GetWalletInstanceStatusHandler", () => {
       batchPatch: () => TE.left(new Error("not implemented")),
       getByUserId: () => TE.left(new ServiceUnavailableError("foo")),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/set-wallet-instance-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/set-wallet-instance-status.spec.ts
@@ -22,6 +22,7 @@ describe("SetWalletInstanceStatusHandler", () => {
     batchPatch: () => TE.right(undefined),
     getByUserId: () => TE.left(new Error("not implemented")),
     getLastByUserId: () => TE.left(new Error("not implemented")),
+    getValidByUserId: () => TE.left(new Error("not implemented")),
     getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
     insert: () => TE.left(new Error("not implemented")),
   };
@@ -111,6 +112,7 @@ describe("SetWalletInstanceStatusHandler", () => {
       },
       getByUserId: () => TE.left(new Error("not implemented")),
       getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("not implemented")),
       getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
       insert: () => TE.left(new Error("not implemented")),
     };
@@ -148,6 +150,7 @@ describe("SetWalletInstanceStatusHandler", () => {
         batchPatch: () => TE.left(new Error("failed on batchPatch!")),
         getByUserId: () => TE.left(new Error("not implemented")),
         getLastByUserId: () => TE.left(new Error("not implemented")),
+        getValidByUserId: () => TE.left(new Error("not implemented")),
         getValidByUserIdExcludingOne: () =>
           TE.left(new Error("not implemented")),
         insert: () => TE.left(new Error("not implemented")),

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/set-wallet-instances-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/set-wallet-instances-status.spec.ts
@@ -1,0 +1,291 @@
+import * as H from "@pagopa/handler-kit";
+import * as L from "@pagopa/logger";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as O from "fp-ts/Option";
+import * as TE from "fp-ts/TaskEither";
+import { describe, expect, it } from "vitest";
+
+import { WalletInstanceRepository } from "@/wallet-instance";
+
+import { SetWalletInstancesStatusHandler } from "../set-wallet-instances-status";
+import { ServiceUnavailableError } from "io-wallet-common/error";
+
+describe("SetWalletInstancesStatusHandler", () => {
+  const logger = {
+    format: L.format.simple,
+    log: () => () => void 0,
+  };
+
+  const validWalletInstance = {
+    createdAt: new Date(),
+    deviceDetails: {
+      attestationSecurityLevel: 2,
+      attestationVersion: 4,
+      keymasterSecurityLevel: 2,
+      keymasterVersion: 4,
+      osPatchLevel: 202410,
+      osVersion: 14,
+      platform: "android" as const,
+      x509Chain: [
+        "-----BEGIN CERTIFICATE-----\nMIIDXTCCAkWgAwIBAgIJAKL0UG+mRKSzMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV\nBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMSEwHwYDVQQKDBhJbnRlcm5ldCBX\naWRnaXRzIFB0eSBMdGQwHhcNMjMwMTAxMDAwMDAwWhcNMjQwMTAxMDAwMDAwWjBF\nMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEhMB8GA1UECgwYSW50\nZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB\nCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onL\nRnrq0/IzKP6aoIIp0FPE0oL0KqRgXNP7CPfS45pz5pnrWPpnK6WEkDaWBLF8axd7\nPE0gfLVJB7F/Mqw8RDBxkXXjE/CuRaU1WP6Y5vvKvXcVY8YIc7wKkPPnKCL8pGqX\nYaFQ6LALSYSLeFcfCOJLs3a6b3JHRGLxPG8uP5V4B6EWWHPvlNlL8iFPBLwL7MhK\nmREJFN4vCG7BEE6vLRPvEU4BVJvqXPGZ7sSL2mLqLvCTH6rJ3cLqQCCj9TShfNp8\nqGIGiPQTcR5hg7qGCqMNCB7qyROhcQIDAQABo1AwTjAdBgNVHQ4EFgQUXH/C9TcY\nu7XFHRFj3GQqNkBfKD0wHwYDVR0jBBgwFoAUXH/C9TcYu7XFHRFj3GQqNkBfKD0w\nDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAMmPv5f1MqEauS7cJb2Kq\nPDFTdWHF8mCPpqFP5KBxKPbLB8CmhDKI7EPCL7f+x6fQX5PV9VqTFJ6z5RGH7bG9\nyWG8xHJZGVOBqmC2+Lcy+MYmvGN7RdYF5hYQF+1cEL7LmK8fP9N0VF/3JgGLqTtK\noXbHDTaLvFCTBdqBKFNl9qwPKN8JV3pWHQKLw/f6HvkpJLjBhAqQ5N8o7YKQQMOP\ny+vKzLVG3xlmLFKV2DhJHWqUJaGp9eW+vqQqONTnWpwPFvGvYzxfPUkQYVNQHZG7\nZQ8CJmUXGPPP3GYLCh5mNqGKLqQCVqFgWCPQzKCKPqEK8rVA4YJbIFMxNNTcGT5V\nTA==\n-----END CERTIFICATE-----\n",
+      ],
+    },
+    hardwareKey: {
+      crv: "P-256",
+      kty: "EC" as const,
+      x: "z3PTdkV20dwTADp2Xur5AXqLbQz7stUbvRNghMQu1rY",
+      y: "Z7MC2EHmlPuoYDRVfy-upr_06-lBYobEk_TCwuSb2ho",
+    },
+    id: "123" as NonEmptyString,
+    isRevoked: false as const,
+    signCount: 0,
+    userId: "AAACCC91D55H501P" as FiscalCode,
+  };
+
+  const request = {
+    ...H.request("https://wallet-provider.example.org/"),
+    body: {
+      fiscal_code: "GSPMTA98L25E625O",
+      reason: "USER_DECEASED",
+      status: "REVOKED",
+    },
+    method: "POST",
+  };
+
+  it("should return a 204 HTTP response on success", async () => {
+    let batchPatchCalled = false;
+    const walletInstanceRepository: WalletInstanceRepository = {
+      batchPatch: () => {
+        batchPatchCalled = true;
+        return TE.right(undefined);
+      },
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.right(O.some([validWalletInstance])),
+      getValidByUserIdExcludingOne: () =>
+        TE.right(O.some([validWalletInstance])),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+
+    const handler = SetWalletInstancesStatusHandler({
+      input: request,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        statusCode: 204,
+      }),
+    });
+    expect(batchPatchCalled).toBe(true);
+  });
+
+  it("should return a 204 HTTP response when there are no valid wallet instances", async () => {
+    let batchPatchCalled = false;
+    const walletInstanceRepository: WalletInstanceRepository = {
+      batchPatch: () => {
+        batchPatchCalled = true;
+        return TE.right(undefined);
+      },
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.right(O.none),
+      getValidByUserIdExcludingOne: () => TE.right(O.none),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+
+    const handler = SetWalletInstancesStatusHandler({
+      input: request,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        statusCode: 204,
+      }),
+    });
+    expect(batchPatchCalled).toBe(false);
+  });
+
+  it("should return a 422 HTTP response on invalid status", async () => {
+    const walletInstanceRepository: WalletInstanceRepository = {
+      batchPatch: () => TE.right(undefined),
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.right(O.none),
+      getValidByUserIdExcludingOne: () => TE.right(O.none),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+
+    const handler = SetWalletInstancesStatusHandler({
+      input: {
+        ...request,
+        body: {
+          ...request.body,
+          status: "foo",
+        },
+      },
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+        statusCode: 422,
+      }),
+    });
+  });
+
+  it("should return a 422 HTTP response on invalid reason", async () => {
+    const walletInstanceRepository: WalletInstanceRepository = {
+      batchPatch: () => TE.right(undefined),
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.right(O.none),
+      getValidByUserIdExcludingOne: () => TE.right(O.none),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+
+    const handler = SetWalletInstancesStatusHandler({
+      input: {
+        ...request,
+        body: {
+          ...request.body,
+          reason: "NEW_WALLET_INSTANCE_CREATED",
+        },
+      },
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+        statusCode: 422,
+      }),
+    });
+  });
+
+  it("should return a 500 HTTP response when getValidByUserId returns Error", async () => {
+    const walletInstanceRepositoryThatFails: WalletInstanceRepository = {
+      batchPatch: () => TE.right(undefined),
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new Error("foo")),
+      getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+    const handler = SetWalletInstancesStatusHandler({
+      input: request,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository: walletInstanceRepositoryThatFails,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+        statusCode: 500,
+      }),
+    });
+  });
+
+  it("should return a 500 HTTP response when batchPatch returns Error", async () => {
+    const walletInstanceRepositoryThatFails: WalletInstanceRepository = {
+      batchPatch: () => TE.left(new Error("foo")),
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.right(O.some([validWalletInstance])),
+      getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+    const handler = SetWalletInstancesStatusHandler({
+      input: request,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository: walletInstanceRepositoryThatFails,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+        statusCode: 500,
+      }),
+    });
+  });
+
+  it("should return a 503 HTTP response when getValidByUserId returns ServiceUnavailableError", async () => {
+    const walletInstanceRepositoryThatFails: WalletInstanceRepository = {
+      batchPatch: () => TE.right(undefined),
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.left(new ServiceUnavailableError("foo")),
+      getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+    const handler = SetWalletInstancesStatusHandler({
+      input: request,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository: walletInstanceRepositoryThatFails,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+        statusCode: 503,
+      }),
+    });
+  });
+
+  it("should return a 503 HTTP response when batchPatch returns ServiceUnavailableError", async () => {
+    const walletInstanceRepositoryThatFails: WalletInstanceRepository = {
+      batchPatch: () => TE.left(new ServiceUnavailableError("foo")),
+      getByUserId: () => TE.left(new Error("not implemented")),
+      getLastByUserId: () => TE.left(new Error("not implemented")),
+      getValidByUserId: () => TE.right(O.some([validWalletInstance])),
+      getValidByUserIdExcludingOne: () => TE.left(new Error("not implemented")),
+      insert: () => TE.left(new Error("not implemented")),
+    };
+    const handler = SetWalletInstancesStatusHandler({
+      input: request,
+      inputDecoder: H.HttpRequest,
+      logger,
+      walletInstanceRepository: walletInstanceRepositoryThatFails,
+    });
+
+    await expect(handler()).resolves.toEqual({
+      _tag: "Right",
+      right: expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/problem+json",
+        }),
+        statusCode: 503,
+      }),
+    });
+  });
+});

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/set-wallet-instances-status.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/set-wallet-instances-status.spec.ts
@@ -1,14 +1,15 @@
+/* eslint-disable max-lines-per-function */
 import * as H from "@pagopa/handler-kit";
 import * as L from "@pagopa/logger";
 import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as O from "fp-ts/Option";
 import * as TE from "fp-ts/TaskEither";
+import { ServiceUnavailableError } from "io-wallet-common/error";
 import { describe, expect, it } from "vitest";
 
 import { WalletInstanceRepository } from "@/wallet-instance";
 
 import { SetWalletInstancesStatusHandler } from "../set-wallet-instances-status";
-import { ServiceUnavailableError } from "io-wallet-common/error";
 
 describe("SetWalletInstancesStatusHandler", () => {
   const logger = {

--- a/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instances-status.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/set-wallet-instances-status.ts
@@ -1,0 +1,69 @@
+import * as H from "@pagopa/handler-kit";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+import * as E from "fp-ts/lib/Either";
+import { flow, pipe } from "fp-ts/lib/function";
+import * as RTE from "fp-ts/lib/ReaderTaskEither";
+import * as t from "io-ts";
+import { logErrorAndReturnResponse } from "io-wallet-common/infra/http/error";
+import { RevocationReason } from "io-wallet-common/wallet-instance";
+
+import { sendTelemetryException } from "@/infra/telemetry";
+import {
+  getUserValidWalletInstancesId,
+  revokeUserWalletInstances,
+} from "@/wallet-instance";
+
+const SetWalletInstancesStatusBody = t.type({
+  fiscal_code: FiscalCode,
+  reason: t.literal("USER_DECEASED"),
+  status: t.literal("REVOKED"),
+});
+
+const requireSetWalletInstancesStatusBody: (
+  req: H.HttpRequest,
+) => E.Either<
+  Error,
+  { fiscalCode: FiscalCode; revocationReason: RevocationReason }
+> = (req) =>
+  pipe(
+    req.body,
+    H.parse(SetWalletInstancesStatusBody),
+    E.map((body) => ({
+      fiscalCode: body.fiscal_code,
+      revocationReason: body.reason,
+    })),
+  );
+
+export const SetWalletInstancesStatusHandler = H.of((req: H.HttpRequest) =>
+  pipe(
+    req,
+    requireSetWalletInstancesStatusBody,
+    RTE.fromEither,
+    RTE.chainW(({ fiscalCode, revocationReason }) =>
+      pipe(
+        fiscalCode,
+        getUserValidWalletInstancesId,
+        RTE.chainW((walletInstancesId) =>
+          revokeUserWalletInstances(
+            fiscalCode,
+            walletInstancesId,
+            revocationReason,
+          ),
+        ),
+        RTE.orElseFirstW(
+          flow(
+            sendTelemetryException({
+              fiscalCode,
+              functionName: "setWalletInstancesStatus",
+              pathParameter: req.path,
+              payload: req.body,
+            }),
+            RTE.fromEither,
+          ),
+        ),
+      ),
+    ),
+    RTE.map(() => H.empty),
+    RTE.orElseW(logErrorAndReturnResponse),
+  ),
+);

--- a/apps/io-wallet-user-func/src/wallet-instance.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance.ts
@@ -35,6 +35,9 @@ export interface WalletInstanceRepository {
   getLastByUserId: (
     userId: WalletInstance["userId"],
   ) => TE.TaskEither<Error, O.Option<WalletInstance>>;
+  getValidByUserId: (
+    userId: WalletInstance["userId"],
+  ) => TE.TaskEither<Error, O.Option<WalletInstanceValid[]>>;
   getValidByUserIdExcludingOne: (
     walletInstanceId: WalletInstance["id"],
     userId: WalletInstance["userId"],
@@ -217,3 +220,22 @@ export const revokeUserValidWalletInstancesExceptOne: (
       ),
     ),
   );
+
+export const getUserValidWalletInstancesId: (
+  userId: WalletInstance["userId"],
+) => RTE.ReaderTaskEither<
+  WalletInstanceEnvironment,
+  Error,
+  readonly WalletInstanceValid["id"][]
+> =
+  (userId) =>
+  ({ walletInstanceRepository }) =>
+    pipe(
+      walletInstanceRepository.getValidByUserId(userId),
+      TE.map(
+        O.match(
+          () => [],
+          RA.map((walletInstance) => walletInstance.id),
+        ),
+      ),
+    );

--- a/packages/io-wallet-common/src/wallet-instance.ts
+++ b/packages/io-wallet-common/src/wallet-instance.ts
@@ -46,6 +46,7 @@ export const RevocationReason = t.union([
   t.literal("NEW_WALLET_INSTANCE_CREATED"),
   t.literal("WALLET_INSTANCE_RENEWAL"),
   t.literal("REVOKED_BY_USER"),
+  t.literal("USER_DECEASED"),
 ]);
 export type RevocationReason = t.TypeOf<typeof RevocationReason>;
 

--- a/packages/io-wallet-common/tsconfig.json
+++ b/packages/io-wallet-common/tsconfig.json
@@ -10,5 +10,7 @@
     "sourceMap": true,
     "declaration": true,
     "noEmit": false
-  }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/__tests__/**"]
 }


### PR DESCRIPTION
Add a new revocation endpoint: `POST /wallet-instances/status`.

The endpoint revokes all valid wallet instances for a given fiscal code, accepting `status=REVOKED` and `reason=USER_DECEASED`, and returns 204 on success (422/500/503 on errors).