### PR TITLE
chore: derive JWT alg from EC key curve

### DIFF
--- a/.changeset/better-oranges-lie.md
+++ b/.changeset/better-oranges-lie.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-user-func": patch
+---
+
+Derive JWT alg from EC curve

--- a/apps/io-wallet-user-func/src/app/config.ts
+++ b/apps/io-wallet-user-func/src/app/config.ts
@@ -230,21 +230,50 @@ const EntityConfigurationConfig = t.type({
 
 type EntityConfigurationConfig = t.TypeOf<typeof EntityConfigurationConfig>;
 
+const isSupportedSigningCurve = (
+  crv: string,
+): crv is "P-256" | "P-384" | "P-521" =>
+  crv === "P-256" || crv === "P-384" || crv === "P-521";
+
+const SupportedECPrivateKeyWithKid = new t.Type<
+  ECPrivateKeyWithKid,
+  ECPrivateKeyWithKid,
+  unknown
+>(
+  "SupportedECPrivateKeyWithKid",
+  (input): input is ECPrivateKeyWithKid =>
+    ECPrivateKeyWithKid.is(input) && isSupportedSigningCurve(input.crv),
+  (input, context) =>
+    pipe(
+      ECPrivateKeyWithKid.validate(input, context),
+      E.chain((key) =>
+        isSupportedSigningCurve(key.crv)
+          ? t.success(key)
+          : t.failure(
+              key.crv,
+              context,
+              `The curve ${key.crv} is not supported for signing keys`,
+            ),
+      ),
+    ),
+  t.identity,
+);
+
 const WalletProviderConfig = t.type({
   certificate: t.type({
     country: t.string,
     locality: t.string,
     state: t.string,
   }),
-  intermediateSigningKey: ECPrivateKeyWithKid,
-  intermediateSigningKeys: t.array(ECPrivateKeyWithKid),
+  intermediateSigningKey: SupportedECPrivateKeyWithKid,
+  intermediateSigningKeys: t.array(SupportedECPrivateKeyWithKid),
   leafResolvedSigningKeys: t.type({
-    tokenStatusList: ECPrivateKeyWithKid,
-    walletAttestation: ECPrivateKeyWithKid,
-    walletInstanceAttestation: ECPrivateKeyWithKid,
-    walletUnitAttestation: ECPrivateKeyWithKid,
+    tokenStatusList: SupportedECPrivateKeyWithKid,
+    walletAttestation: SupportedECPrivateKeyWithKid,
+    walletInstanceAttestation: SupportedECPrivateKeyWithKid,
+    walletUnitAttestation: SupportedECPrivateKeyWithKid,
   }),
-  leafSigningKeys: t.array(ECPrivateKeyWithKid),
+  leafSigningKeys: t.array(SupportedECPrivateKeyWithKid),
   walletAttestation: t.type({
     oauthClientSub: t.string,
     walletLink: t.string,
@@ -271,7 +300,7 @@ export type Config = t.TypeOf<typeof Config>;
 const readJwksFromEnvironment = flow(
   readFromEnvironment,
   RE.chainEitherKW(fromBase64ToJwks),
-  RE.chainEitherKW(parse(t.array(ECPrivateKeyWithKid))),
+  RE.chainEitherKW(parse(t.array(SupportedECPrivateKeyWithKid))),
 );
 
 const getSigningKeyByKid = (jwks: ECPrivateKeyWithKid[], kid: string) =>

--- a/apps/io-wallet-user-func/src/infra/crypto/signer.ts
+++ b/apps/io-wallet-user-func/src/infra/crypto/signer.ts
@@ -1,15 +1,12 @@
 import { pipe } from "fp-ts/function";
-import * as A from "fp-ts/lib/Array";
 import * as E from "fp-ts/lib/Either";
-import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
 import { ECPrivateKeyWithKid } from "io-wallet-common/jwk";
 import * as jose from "jose";
 
-const supportedSignAlgorithms = ["ES256"];
+export type SignAlgorithm = "ES256" | "ES384" | "ES512";
 
 interface JwtHeader {
-  alg?: string;
   trustChain?: string[];
   typ: string;
   x5c?: string[];
@@ -21,26 +18,29 @@ interface SignJwtOptions {
   payload: jose.JWTPayload;
 }
 
-const isAlgorithmSupported = (alg: string) =>
-  pipe(
-    supportedSignAlgorithms,
-    A.findFirst((supportedAlg) => supportedAlg === alg),
-    O.isSome,
-  );
+export const getSignAlgorithmFromCurve = (crv: string): SignAlgorithm => {
+  switch (crv) {
+    case "P-256":
+      return "ES256";
+    case "P-384":
+      return "ES384";
+    case "P-521":
+      return "ES512";
+    default:
+      throw new Error(`The curve ${crv} is not supported`);
+  }
+};
 
 export const signJwt =
   (privateKey: ECPrivateKeyWithKid) =>
   ({
     duration = "24h",
-    header: { alg = "ES256", trustChain, ...header },
+    header: { trustChain, ...header },
     payload,
   }: SignJwtOptions) =>
     pipe(
-      alg,
-      TE.fromPredicate(
-        isAlgorithmSupported,
-        (a) => new Error(`The algorithm ${a} is not supported`),
-      ),
+      E.tryCatch(() => getSignAlgorithmFromCurve(privateKey.crv), E.toError),
+      TE.fromEither,
       TE.chain((alg) =>
         pipe(
           TE.tryCatch(() => jose.importJWK(privateKey), E.toError),

--- a/apps/io-wallet-user-func/src/infra/handlers/generate-entity-configuration.ts
+++ b/apps/io-wallet-user-func/src/infra/handlers/generate-entity-configuration.ts
@@ -117,7 +117,6 @@ const createEntityConfiguration: RTE.ReaderTaskEither<
                 // TODO: SIW-2656. env var are not used
                 duration: "24h",
                 header: {
-                  alg: "ES256",
                   typ: "entity-statement+jwt",
                 },
                 payload,

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-instance-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-instance-attestation.spec.ts
@@ -10,10 +10,11 @@ import {
 import { UrlFromString } from "@pagopa/ts-commons/lib/url";
 import { decode } from "cbor-x";
 import * as E from "fp-ts/Either";
-import { flow } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/Option";
 import * as TE from "fp-ts/TaskEither";
 import * as t from "io-ts";
+import { ECPrivateKeyWithKid } from "io-wallet-common/jwk";
 import * as jose from "jose";
 import { describe, expect, it, vi } from "vitest";
 
@@ -111,6 +112,25 @@ const certificateRepository: CertificateRepository = {
 
 const data = Buffer.from(assertion, "base64");
 const { authenticatorData, signature } = decode(data);
+
+const generateP521PrivateJwk = (kid: string): Promise<ECPrivateKeyWithKid> =>
+  jose
+    .generateKeyPair("ES512", {
+      extractable: true,
+    })
+    .then(({ privateKey }) => jose.exportJWK(privateKey))
+    .then((jwk) =>
+      pipe(
+        {
+          ...jwk,
+          kid,
+        },
+        ECPrivateKeyWithKid.decode,
+        E.getOrElseW((_) => {
+          throw new Error(`Failed to decode P-521 private JWK ${_[0].value}`);
+        }),
+      ),
+    );
 
 vi.mock("@/infra/mobile-attestation-service", async (importOriginal) => {
   const actual =
@@ -312,6 +332,123 @@ describe("CreateWalletInstanceAttestationHandler", async () => {
         expect((walletInstanceAttPayload.sub || "").endsWith("/")).toBe(false);
       }
     }
+  });
+
+  it("should sign the jwt with the algorithm derived from the provider key curve - P-521", async () => {
+    const p521SigningKey = await generateP521PrivateJwk("p521#wia");
+    const handler = CreateWalletInstanceAttestationHandler({
+      assertionValidationConfig,
+      certificateRepository,
+      federationEntity,
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      nonceRepository,
+      walletAttestationConfig,
+      walletInstanceAttestationSigningKey: p521SigningKey,
+      walletInstanceRepository,
+    });
+
+    const result = await handler();
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isLeft(result)) {
+      throw result.left;
+    }
+
+    const body = t
+      .type({
+        wallet_instance_attestation: t.string,
+      })
+      .decode(result.right.body);
+
+    expect(E.isRight(body)).toBe(true);
+    if (E.isLeft(body)) {
+      throw new Error("Invalid response body");
+    }
+
+    const walletInstanceAttestation = body.right.wallet_instance_attestation;
+    expect(jose.decodeProtectedHeader(walletInstanceAttestation)).toMatchObject(
+      {
+        alg: "ES512",
+        kid: p521SigningKey.kid,
+      },
+    );
+
+    const payload = t
+      .type({
+        cnf: t.type({
+          jwk: t.type({
+            alg: t.string,
+          }),
+        }),
+      })
+      .decode(jose.decodeJwt(walletInstanceAttestation));
+
+    expect(E.isRight(payload)).toBe(true);
+    if (E.isLeft(payload)) {
+      throw new Error("Invalid wallet instance attestation payload");
+    }
+
+    expect(payload.right.cnf.jwk.alg).toBe("ES256");
+  });
+
+  it("should sign the jwt with the algorithm derived from the provider key curve - P-256", async () => {
+    const handler = CreateWalletInstanceAttestationHandler({
+      assertionValidationConfig,
+      certificateRepository,
+      federationEntity,
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      nonceRepository,
+      walletAttestationConfig,
+      walletInstanceAttestationSigningKey: privateEcKey,
+      walletInstanceRepository,
+    });
+
+    const result = await handler();
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isLeft(result)) {
+      throw result.left;
+    }
+
+    const body = t
+      .type({
+        wallet_instance_attestation: t.string,
+      })
+      .decode(result.right.body);
+
+    expect(E.isRight(body)).toBe(true);
+    if (E.isLeft(body)) {
+      throw new Error("Invalid response body");
+    }
+
+    const walletInstanceAttestation = body.right.wallet_instance_attestation;
+    expect(jose.decodeProtectedHeader(walletInstanceAttestation)).toMatchObject(
+      {
+        alg: "ES256",
+        kid: privateEcKey.kid,
+      },
+    );
+
+    const payload = t
+      .type({
+        cnf: t.type({
+          jwk: t.type({
+            alg: t.string,
+          }),
+        }),
+      })
+      .decode(jose.decodeJwt(walletInstanceAttestation));
+
+    expect(E.isRight(payload)).toBe(true);
+    if (E.isLeft(payload)) {
+      throw new Error("Invalid wallet instance attestation payload");
+    }
+
+    expect(payload.right.cnf.jwk.alg).toBe("ES256");
   });
 
   it("should return a 500 HTTP response when getCertificateChainByKid returns an error", async () => {

--- a/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-unit-attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/__tests__/create-wallet-unit-attestation.spec.ts
@@ -10,10 +10,11 @@ import {
 import { UrlFromString } from "@pagopa/ts-commons/lib/url";
 import { decode } from "cbor-x";
 import * as E from "fp-ts/Either";
-import { flow } from "fp-ts/lib/function";
+import { flow, pipe } from "fp-ts/lib/function";
 import * as O from "fp-ts/Option";
 import * as TE from "fp-ts/TaskEither";
 import * as t from "io-ts";
+import { ECPrivateKeyWithKid } from "io-wallet-common/jwk";
 import * as jose from "jose";
 import { describe, expect, it, vi } from "vitest";
 
@@ -124,6 +125,25 @@ const certificateRepository: CertificateRepository = {
 
 const data = Buffer.from(assertion, "base64");
 const { authenticatorData, signature } = decode(data);
+
+const generateP521PrivateJwk = (kid: string): Promise<ECPrivateKeyWithKid> =>
+  jose
+    .generateKeyPair("ES512", {
+      extractable: true,
+    })
+    .then(({ privateKey }) => jose.exportJWK(privateKey))
+    .then((jwk) =>
+      pipe(
+        {
+          ...jwk,
+          kid,
+        },
+        ECPrivateKeyWithKid.decode,
+        E.getOrElseW((_) => {
+          throw new Error(`Failed to decode P-521 private JWK ${_[0].value}`);
+        }),
+      ),
+    );
 
 vi.mock("@/infra/mobile-attestation-service", async (importOriginal) => {
   const actual =
@@ -356,6 +376,89 @@ describe("CreateWalletUnitAttestationHandler", async () => {
         }),
         statusCode: 200,
       }),
+    });
+  });
+
+  it("should sign the jwt with the algorithm derived from the provider key curve - P-521", async () => {
+    const p521SigningKey = await generateP521PrivateJwk("p521#wua");
+    const handler = CreateWalletUnitAttestationHandler({
+      androidAttestationValidationConfig,
+      assertionValidationConfig,
+      certificateRepository,
+      federationEntity,
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      nonceRepository,
+      statusListBaseUrl,
+      walletInstanceRepository,
+      walletUnitAttestationSigningKey: p521SigningKey,
+    });
+
+    const result = await handler();
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isLeft(result)) {
+      throw result.left;
+    }
+
+    const body = t
+      .type({
+        wallet_unit_attestation: t.string,
+      })
+      .decode(result.right.body);
+
+    expect(E.isRight(body)).toBe(true);
+    if (E.isLeft(body)) {
+      throw new Error("Invalid response body");
+    }
+
+    expect(
+      jose.decodeProtectedHeader(body.right.wallet_unit_attestation),
+    ).toMatchObject({
+      alg: "ES512",
+      kid: p521SigningKey.kid,
+    });
+  });
+
+  it("should sign the jwt with the algorithm derived from the provider key curve - P-256", async () => {
+    const handler = CreateWalletUnitAttestationHandler({
+      androidAttestationValidationConfig,
+      assertionValidationConfig,
+      certificateRepository,
+      federationEntity,
+      input: req,
+      inputDecoder: H.HttpRequest,
+      logger,
+      nonceRepository,
+      statusListBaseUrl,
+      walletInstanceRepository,
+      walletUnitAttestationSigningKey: privateEcKey,
+    });
+
+    const result = await handler();
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isLeft(result)) {
+      throw result.left;
+    }
+
+    const body = t
+      .type({
+        wallet_unit_attestation: t.string,
+      })
+      .decode(result.right.body);
+
+    expect(E.isRight(body)).toBe(true);
+    if (E.isLeft(body)) {
+      throw new Error("Invalid response body");
+    }
+
+    expect(
+      jose.decodeProtectedHeader(body.right.wallet_unit_attestation),
+    ).toMatchObject({
+      alg: "ES256",
+      kid: privateEcKey.kid,
     });
   });
 

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-attestation.ts
@@ -85,7 +85,6 @@ const signWalletAttestationJwt =
     signJwt(walletAttestationSigningKey)({
       duration: "1h",
       header: {
-        alg: "ES256",
         typ: "oauth-client-attestation+jwt",
       },
       payload,
@@ -106,7 +105,6 @@ const signWalletAttestationSdJwt =
         // TODO: SIW-2656. env var are not used
         duration: "1h",
         header: {
-          alg: "ES256",
           typ: "dc+sd-jwt",
         },
         payload: { ...claims },

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance-attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-instance-attestation.ts
@@ -9,7 +9,7 @@ import { type JWTPayload } from "jose";
 
 import { CertificateRepository } from "@/certificates";
 import { FederationEntity } from "@/entity-configuration";
-import { signJwt } from "@/infra/crypto/signer";
+import { getSignAlgorithmFromCurve, signJwt } from "@/infra/crypto/signer";
 import { AssertionValidationConfig } from "@/infra/mobile-attestation-service";
 import { toThumbprint } from "@/infra/mobile-attestation-service";
 import { validateWalletInstanceAssertionRequest } from "@/infra/mobile-attestation-service/assertion-request-validation";
@@ -52,7 +52,6 @@ const signWalletInstanceAttestation =
     signJwt(walletInstanceAttestationSigningKey)({
       duration: "1h",
       header: {
-        alg: "ES256",
         typ: "oauth-client-attestation+jwt",
         x5c,
       },
@@ -91,6 +90,7 @@ const getWalletInstanceAttestationData =
       ),
       TE.map(({ sub, x5c }) => ({
         jwk: input.cnf.jwk,
+        jwkAlg: getSignAlgorithmFromCurve(input.cnf.jwk.crv),
         kid: walletInstanceAttestationSigningKey.kid,
         sub,
         walletProviderName: basePath.href,

--- a/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-unit-attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/create-wallet-unit-attestation.ts
@@ -59,7 +59,6 @@ const signWalletUnitAttestation =
     signJwt(walletUnitAttestationSigningKey)({
       duration: "1y",
       header: {
-        alg: "ES256",
         typ: "key-attestation+jwt",
         x5c,
       },

--- a/apps/io-wallet-user-func/src/infra/http/handlers/generate-certificate-chain.ts
+++ b/apps/io-wallet-user-func/src/infra/http/handlers/generate-certificate-chain.ts
@@ -56,21 +56,23 @@ const jwkToCryptoKey: (
 ) => RTE.ReaderTaskEither<CertificateEnvironment, Error, CryptoKey> =
   (jwk) =>
   ({ certificate: { crypto } }) =>
-    TE.tryCatch(
-      () =>
-        crypto.subtle.importKey(
-          "jwk",
-          jwk,
-          {
-            name: "ECDSA",
-            namedCurve: "P-256",
-          },
-          true,
-          ["d" in jwk ? "sign" : "verify"], // "sign" if private; "verify" if public
-        ),
-      (reason) =>
-        reason instanceof Error ? reason : new Error(String(reason)),
-    );
+    jwk.kty !== "EC"
+      ? TE.left(new Error(`The key type ${jwk.kty} is not supported`))
+      : TE.tryCatch(
+          () =>
+            crypto.subtle.importKey(
+              "jwk",
+              jwk,
+              {
+                name: "ECDSA",
+                namedCurve: jwk.crv,
+              },
+              true,
+              ["d" in jwk ? "sign" : "verify"], // "sign" if private; "verify" if public
+            ),
+          (reason) =>
+            reason instanceof Error ? reason : new Error(String(reason)),
+        );
 
 const issueX509Certificate: (input: {
   publicKey: CryptoKey;

--- a/apps/io-wallet-user-func/src/infra/status-list-publication.ts
+++ b/apps/io-wallet-user-func/src/infra/status-list-publication.ts
@@ -312,7 +312,6 @@ export class StatusListPublicationService implements StatusListPublication {
         signJwt(this.tokenStatusListSigningKey)({
           duration: statusListJwtDuration,
           header: {
-            alg: "ES256",
             typ: statusListJwtType,
             x5c,
           },

--- a/apps/io-wallet-user-func/src/wallet-instance-attestation.ts
+++ b/apps/io-wallet-user-func/src/wallet-instance-attestation.ts
@@ -1,10 +1,13 @@
 import * as E from "io-ts/lib/Encoder";
 import { JwkPublicKey } from "io-wallet-common/jwk";
 
+import type { SignAlgorithm } from "./infra/crypto/signer";
+
 import { removeTrailingSlash } from "./url";
 
 export interface WalletInstanceAttestationData {
   jwk: JwkPublicKey;
+  jwkAlg: SignAlgorithm;
   kid: string;
   // oauthClientSub: string;
   sub: string;
@@ -16,7 +19,7 @@ export interface WalletInstanceAttestationData {
 interface WalletInstanceAttestationJwtModel {
   cnf: {
     jwk: JwkPublicKey & {
-      alg: "ES256";
+      alg: SignAlgorithm;
     };
   };
   // eudi_wallet_info: {
@@ -39,6 +42,7 @@ export const WalletInstanceAttestationToJwtModel: E.Encoder<
 > = {
   encode: ({
     jwk,
+    jwkAlg,
     // oauthClientSub,
     sub,
     walletProviderName,
@@ -48,7 +52,7 @@ export const WalletInstanceAttestationToJwtModel: E.Encoder<
     cnf: {
       jwk: {
         ...jwk,
-        alg: "ES256",
+        alg: jwkAlg,
       },
     },
     // eudi_wallet_info: {


### PR DESCRIPTION
Derives JWT signing algorithms from the EC key curve instead of hardcoding ES256.

Updates signing flows and tests to support P-256, P-384, and P-521 keys, mapping them to ES256, ES384, and ES512 respectively. Also removes caller-provided `alg` from `signJwt` so the protected header is always consistent with the private key used for signing.