### PR TITLE
fix: [SIW-4620] Removed expiration check root certificate android

### DIFF
--- a/.changeset/red-drinks-visit.md
+++ b/.changeset/red-drinks-visit.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-user-func": patch
+---
+
+Fix android root expiry handling and chain validation

--- a/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
+++ b/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
@@ -66,4 +66,106 @@ describe("CertificatesValidation", () => {
     const validation = validateIssuance(validChain, [fakePublicKey]);
     expect(validation).toHaveProperty("success", false);
   });
+
+  it("should ignore expiration on the root certificate when requested", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === intermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
+    const validation = validateIssuance(
+      fakeChain,
+      [rootPublicKey as never],
+      true,
+    );
+
+    expect(validation).toHaveProperty("success", true);
+  });
+
+  it("should still reject expired non-root certificates when skipping only root expiration", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === intermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now - 30_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
+    const validation = validateIssuance(
+      fakeChain,
+      [rootPublicKey as never],
+      true,
+    );
+
+    expect(validation).toHaveProperty("success", false);
+  });
+
+  it("should reject a chain when a certificate is not signed by its parent", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const wrongIntermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === wrongIntermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never]);
+
+    expect(validation).toHaveProperty("success", false);
+  });
 });

--- a/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
+++ b/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
@@ -96,6 +96,7 @@ describe("CertificatesValidation", () => {
     const validation = validateIssuance(
       fakeChain,
       [rootPublicKey as never],
+      false,
       true,
     );
 
@@ -131,6 +132,7 @@ describe("CertificatesValidation", () => {
     const validation = validateIssuance(
       fakeChain,
       [rootPublicKey as never],
+      false,
       true,
     );
 

--- a/apps/io-wallet-user-func/src/certificates.ts
+++ b/apps/io-wallet-user-func/src/certificates.ts
@@ -31,13 +31,13 @@ const getRootPublicKey: (
 /**
  * Verify that the root public certificate is trustworthy and that each certificate signs the next certificate in the chain.
  * @param x509Chain - The chain of {@link X509Certificate} certificates. The root certificate must be the last element of the array.
- * @param rootPublicKey - The public key of root certificate.
- * @param skipExpirationvalidation - Skip validation of certificates expiration, default is false.
+ * @param rootPublicKeys - The public keys of the trusted root certificates.
+ * @param skipRootExpirationValidation - Skip validation of the root certificate expiration, default is false.
  */
 export const validateIssuance = (
   x509Chain: readonly X509Certificate[],
   rootPublicKeys: KeyObject[],
-  skipExpirationvalidation = false,
+  skipRootExpirationValidation = false,
 ): ValidationResult => {
   // Check the signature of root certificate with root public key
   const rootPublicKey = getRootPublicKey(x509Chain, rootPublicKeys);
@@ -48,33 +48,37 @@ export const validateIssuance = (
     };
   }
 
-  if (!skipExpirationvalidation) {
-    // Check certificates expiration dates
-    const now = new Date();
-    const datesValid = x509Chain.every(
-      (c) => new Date(c.validFrom) <= now && now <= new Date(c.validTo),
-    );
-    if (!datesValid) {
-      return {
-        reason: `Certificates expired: ${x509Chain}`,
-        success: false,
-      };
-    }
+  // Check certificates expiration dates
+  const now = new Date();
+  const datesValid = x509Chain.every(
+    (c, index) =>
+      (skipRootExpirationValidation && index === x509Chain.length - 1) ||
+      (new Date(c.validFrom) <= now && now <= new Date(c.validTo)),
+  );
+  if (!datesValid) {
+    return {
+      reason: `Certificates expired: ${x509Chain}`,
+      success: false,
+    };
   }
 
   // Check that each certificate, except for the last, is issued by the subsequent one.
   if (x509Chain.length >= 2) {
-    x509Chain.forEach((cert, index) => {
-      if (index < x509Chain.length - 1) {
-        const parent = x509Chain[index + 1];
-        if (!cert || !parent || !cert.verify(parent.publicKey)) {
-          return {
-            reason: `Certificates chain is invalid: ${x509Chain}`,
-            success: false,
-          };
-        }
+    const chainValid = x509Chain.every((cert, index) => {
+      if (index === x509Chain.length - 1) {
+        return true;
       }
+
+      const parent = x509Chain[index + 1];
+      return !!cert && !!parent && cert.verify(parent.publicKey);
     });
+
+    if (!chainValid) {
+      return {
+        reason: `Certificates chain is invalid: ${x509Chain}`,
+        success: false,
+      };
+    }
   }
 
   return { success: true };

--- a/apps/io-wallet-user-func/src/certificates.ts
+++ b/apps/io-wallet-user-func/src/certificates.ts
@@ -32,11 +32,13 @@ const getRootPublicKey: (
  * Verify that the root public certificate is trustworthy and that each certificate signs the next certificate in the chain.
  * @param x509Chain - The chain of {@link X509Certificate} certificates. The root certificate must be the last element of the array.
  * @param rootPublicKeys - The public keys of the trusted root certificates.
+ * @param skipExpirationValidation - Skip validation of all certificates expiration, default is false.
  * @param skipRootExpirationValidation - Skip validation of the root certificate expiration, default is false.
  */
 export const validateIssuance = (
   x509Chain: readonly X509Certificate[],
   rootPublicKeys: KeyObject[],
+  skipExpirationValidation = false,
   skipRootExpirationValidation = false,
 ): ValidationResult => {
   // Check the signature of root certificate with root public key
@@ -48,18 +50,20 @@ export const validateIssuance = (
     };
   }
 
-  // Check certificates expiration dates
-  const now = new Date();
-  const datesValid = x509Chain.every(
-    (c, index) =>
-      (skipRootExpirationValidation && index === x509Chain.length - 1) ||
-      (new Date(c.validFrom) <= now && now <= new Date(c.validTo)),
-  );
-  if (!datesValid) {
-    return {
-      reason: `Certificates expired: ${x509Chain}`,
-      success: false,
-    };
+  if (!skipExpirationValidation) {
+    // Check certificates expiration dates
+    const now = new Date();
+    const datesValid = x509Chain.every(
+      (c, index) =>
+        (skipRootExpirationValidation && index === x509Chain.length - 1) ||
+        (new Date(c.validFrom) <= now && now <= new Date(c.validTo)),
+    );
+    if (!datesValid) {
+      return {
+        reason: `Certificates expired: ${x509Chain}`,
+        success: false,
+      };
+    }
   }
 
   // Check that each certificate, except for the last, is issued by the subsequent one.

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
@@ -62,6 +62,7 @@ export const verifyAttestation = async (
   const issuanceValidationResult = validateIssuance(
     x509Chain,
     publicKeys,
+    false,
     true,
   );
 

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
@@ -59,7 +59,11 @@ export const verifyAttestation = async (
   // 3. Verify that the root public certificate is trustworthy and that each certificate signs the next certificate in the chain.
   const publicKeys = googlePublicKeys.map(createPublicKey);
 
-  const issuanceValidationResult = validateIssuance(x509Chain, publicKeys);
+  const issuanceValidationResult = validateIssuance(
+    x509Chain,
+    publicKeys,
+    true,
+  );
 
   if (!issuanceValidationResult.success) {
     return issuanceValidationResult;


### PR DESCRIPTION
This PR adjusts Android key attestation validation so the root certificate expiration is ignored while the rest of the chain is still validated.