### PR TITLE
fix: [SIW-4665] Fix Android key attestation certificate validity policy

### DIFF
--- a/.changeset/slow-years-leave.md
+++ b/.changeset/slow-years-leave.md
@@ -1,0 +1,5 @@
+---
+"io-wallet-user-func": minor
+---
+
+Updates Android Key Attestation certificate validation to apply the requested RKP/Non-RKP expiration policy

--- a/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
+++ b/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
@@ -68,7 +68,7 @@ describe("CertificatesValidation", () => {
     expect(validation).toHaveProperty("success", false);
   });
 
-  it("should ignore expiration on the root certificate", () => {
+  it("should reject expired root certificates by default", () => {
     const rootPublicKey = {};
     const rootKey = {};
     const intermediateKey = {};
@@ -96,10 +96,43 @@ describe("CertificatesValidation", () => {
 
     const validation = validateIssuance(fakeChain, [rootPublicKey as never]);
 
+    expect(validation).toHaveProperty("success", false);
+  });
+
+  it("should ignore expiration on the root certificate when requested", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === intermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never], {
+      skipLeafAndRootExpirationValidation: true,
+    });
+
     expect(validation).toHaveProperty("success", true);
   });
 
-  it("should reject expired intermediate certificates when skipExpirationValidation flag is false", () => {
+  it("should reject expired intermediate certificates by default", () => {
     const rootPublicKey = {};
     const rootKey = {};
     const intermediateKey = {};
@@ -156,11 +189,10 @@ describe("CertificatesValidation", () => {
       },
     ] as unknown as readonly X509Certificate[];
 
-    const validation = validateIssuance(
-      fakeChain,
-      [rootPublicKey as never],
-      true,
-    );
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never], {
+      skipIntermediateExpirationValidation: true,
+      skipLeafAndRootExpirationValidation: true,
+    });
 
     expect(validation).toHaveProperty("success", true);
   });
@@ -192,11 +224,10 @@ describe("CertificatesValidation", () => {
       },
     ] as unknown as readonly X509Certificate[];
 
-    const validation = validateIssuance(
-      fakeChain,
-      [rootPublicKey as never],
-      true,
-    );
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never], {
+      skipIntermediateExpirationValidation: true,
+      skipLeafAndRootExpirationValidation: true,
+    });
 
     expect(validation).toHaveProperty("success", false);
   });
@@ -227,7 +258,9 @@ describe("CertificatesValidation", () => {
       },
     ] as unknown as readonly X509Certificate[];
 
-    const validation = validateIssuance(fakeChain, [rootPublicKey as never]);
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never], {
+      skipLeafAndRootExpirationValidation: true,
+    });
 
     expect(validation).toHaveProperty("success", true);
   });

--- a/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
+++ b/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
@@ -99,7 +99,7 @@ describe("CertificatesValidation", () => {
     expect(validation).toHaveProperty("success", true);
   });
 
-  it("should reject expired intermediate certificates", () => {
+  it("should reject expired intermediate certificates when skipExpirationValidation flag is false", () => {
     const rootPublicKey = {};
     const rootKey = {};
     const intermediateKey = {};

--- a/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
+++ b/apps/io-wallet-user-func/src/__tests__/certificates.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 import { createPublicKey, X509Certificate } from "crypto";
 import { describe, expect, it } from "vitest";
 
@@ -67,7 +68,7 @@ describe("CertificatesValidation", () => {
     expect(validation).toHaveProperty("success", false);
   });
 
-  it("should ignore expiration on the root certificate when requested", () => {
+  it("should ignore expiration on the root certificate", () => {
     const rootPublicKey = {};
     const rootKey = {};
     const intermediateKey = {};
@@ -93,17 +94,12 @@ describe("CertificatesValidation", () => {
       },
     ] as unknown as readonly X509Certificate[];
 
-    const validation = validateIssuance(
-      fakeChain,
-      [rootPublicKey as never],
-      false,
-      true,
-    );
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never]);
 
     expect(validation).toHaveProperty("success", true);
   });
 
-  it("should still reject expired non-root certificates when skipping only root expiration", () => {
+  it("should reject expired intermediate certificates", () => {
     const rootPublicKey = {};
     const rootKey = {};
     const intermediateKey = {};
@@ -111,14 +107,14 @@ describe("CertificatesValidation", () => {
     const fakeChain = [
       {
         publicKey: {},
-        validFrom: new Date(now - 120_000).toISOString(),
-        validTo: new Date(now - 60_000).toISOString(),
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
         verify: (publicKey: object) => publicKey === intermediateKey,
       },
       {
         publicKey: intermediateKey,
-        validFrom: new Date(now - 60_000).toISOString(),
-        validTo: new Date(now + 60_000).toISOString(),
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
         verify: (publicKey: object) => publicKey === rootKey,
       },
       {
@@ -129,14 +125,111 @@ describe("CertificatesValidation", () => {
       },
     ] as unknown as readonly X509Certificate[];
 
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never]);
+
+    expect(validation).toHaveProperty("success", false);
+  });
+
+  it("should ignore expiration on all certificates when requested", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now + 60_000).toISOString(),
+        validTo: new Date(now + 120_000).toISOString(),
+        verify: (publicKey: object) => publicKey === intermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
     const validation = validateIssuance(
       fakeChain,
       [rootPublicKey as never],
-      false,
+      true,
+    );
+
+    expect(validation).toHaveProperty("success", true);
+  });
+
+  it("should still reject invalid signatures when ignoring expiration", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const wrongIntermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now + 60_000).toISOString(),
+        validTo: new Date(now + 120_000).toISOString(),
+        verify: (publicKey: object) => publicKey === wrongIntermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 120_000).toISOString(),
+        validTo: new Date(now - 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
+    const validation = validateIssuance(
+      fakeChain,
+      [rootPublicKey as never],
       true,
     );
 
     expect(validation).toHaveProperty("success", false);
+  });
+
+  it("should ignore expiration on the leaf certificate", () => {
+    const rootPublicKey = {};
+    const rootKey = {};
+    const intermediateKey = {};
+    const now = Date.now();
+    const fakeChain = [
+      {
+        publicKey: {},
+        validFrom: new Date(now + 60_000).toISOString(),
+        validTo: new Date(now + 120_000).toISOString(),
+        verify: (publicKey: object) => publicKey === intermediateKey,
+      },
+      {
+        publicKey: intermediateKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootKey,
+      },
+      {
+        publicKey: rootKey,
+        validFrom: new Date(now - 60_000).toISOString(),
+        validTo: new Date(now + 60_000).toISOString(),
+        verify: (publicKey: object) => publicKey === rootPublicKey,
+      },
+    ] as unknown as readonly X509Certificate[];
+
+    const validation = validateIssuance(fakeChain, [rootPublicKey as never]);
+
+    expect(validation).toHaveProperty("success", true);
   });
 
   it("should reject a chain when a certificate is not signed by its parent", () => {

--- a/apps/io-wallet-user-func/src/certificates.ts
+++ b/apps/io-wallet-user-func/src/certificates.ts
@@ -11,6 +11,11 @@ import * as path from "path";
 
 import { ValidationResult } from "@/attestation-service";
 
+interface ValidateIssuanceOptions {
+  skipIntermediateExpirationValidation?: boolean;
+  skipLeafAndRootExpirationValidation?: boolean;
+}
+
 const getRootPublicKey: (
   x509Chain: readonly X509Certificate[],
   googlePublicKeys: KeyObject[],
@@ -32,12 +37,12 @@ const getRootPublicKey: (
  * Verify that the root public certificate is trustworthy and that each certificate signs the next certificate in the chain.
  * @param x509Chain - The chain of {@link X509Certificate} certificates. The root certificate must be the last element of the array.
  * @param rootPublicKeys - The public keys of the trusted root certificates.
- * @param skipExpirationValidation - Skip validation of all certificates expiration, default is false.
+ * @param options - Configure certificate expiration validation skips.
  */
 export const validateIssuance = (
   x509Chain: readonly X509Certificate[],
   rootPublicKeys: KeyObject[],
-  skipExpirationValidation = false,
+  options: ValidateIssuanceOptions = {},
 ): ValidationResult => {
   // Check the signature of root certificate with root public key
   const rootPublicKey = getRootPublicKey(x509Chain, rootPublicKeys);
@@ -48,21 +53,23 @@ export const validateIssuance = (
     };
   }
 
-  if (!skipExpirationValidation) {
-    // Check intermediate certificates expiration dates.
-    const now = new Date();
-    const datesValid = x509Chain.every(
-      (c, index) =>
-        index === 0 ||
-        index === x509Chain.length - 1 ||
-        (new Date(c.validFrom) <= now && now <= new Date(c.validTo)),
+  const now = new Date();
+  const datesValid = x509Chain.every((c, index) => {
+    const isLeafOrRoot = index === 0 || index === x509Chain.length - 1;
+    const skipExpirationValidation = isLeafOrRoot
+      ? options.skipLeafAndRootExpirationValidation
+      : options.skipIntermediateExpirationValidation;
+
+    return (
+      skipExpirationValidation ||
+      (new Date(c.validFrom) <= now && now <= new Date(c.validTo))
     );
-    if (!datesValid) {
-      return {
-        reason: `Certificates expired: ${x509Chain}`,
-        success: false,
-      };
-    }
+  });
+  if (!datesValid) {
+    return {
+      reason: `Certificates expired: ${x509Chain}`,
+      success: false,
+    };
   }
 
   // Check that each certificate, except for the last, is issued by the subsequent one.

--- a/apps/io-wallet-user-func/src/certificates.ts
+++ b/apps/io-wallet-user-func/src/certificates.ts
@@ -33,13 +33,11 @@ const getRootPublicKey: (
  * @param x509Chain - The chain of {@link X509Certificate} certificates. The root certificate must be the last element of the array.
  * @param rootPublicKeys - The public keys of the trusted root certificates.
  * @param skipExpirationValidation - Skip validation of all certificates expiration, default is false.
- * @param skipRootExpirationValidation - Skip validation of the root certificate expiration, default is false.
  */
 export const validateIssuance = (
   x509Chain: readonly X509Certificate[],
   rootPublicKeys: KeyObject[],
   skipExpirationValidation = false,
-  skipRootExpirationValidation = false,
 ): ValidationResult => {
   // Check the signature of root certificate with root public key
   const rootPublicKey = getRootPublicKey(x509Chain, rootPublicKeys);
@@ -51,11 +49,12 @@ export const validateIssuance = (
   }
 
   if (!skipExpirationValidation) {
-    // Check certificates expiration dates
+    // Check intermediate certificates expiration dates.
     const now = new Date();
     const datesValid = x509Chain.every(
       (c, index) =>
-        (skipRootExpirationValidation && index === x509Chain.length - 1) ||
+        index === 0 ||
+        index === x509Chain.length - 1 ||
         (new Date(c.validFrom) <= now && now <= new Date(c.validTo)),
     );
     if (!datesValid) {

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/__tests__/attestation.spec.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/__tests__/attestation.spec.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { decodeBase64String, GOOGLE_PUBLIC_KEY } from "@/app/config";
 
 import { base64ToPem } from "..";
-import { verifyAttestation } from "../attestation";
+import { isNonRkpChain, verifyAttestation } from "../attestation";
 import { androidMockData } from "./config";
 
 describe("AndroidAttestationValidation", () => {
@@ -86,5 +86,23 @@ describe("AndroidAttestationValidation", () => {
     };
 
     await expect(result).resolves.toEqual(expectedResult);
+  });
+
+  it("should classify the legacy Google root subject as Non-RKP", () => {
+    const nonRkpChain = [
+      { subject: "CN=leaf" },
+      { subject: "SERIALNUMBER=f92009e853b6b045" },
+    ] as unknown as readonly X509Certificate[];
+
+    expect(isNonRkpChain(nonRkpChain)).toBe(true);
+  });
+
+  it("should classify chains with a different root subject as RKP", () => {
+    const rkpChain = [
+      { subject: "CN=leaf" },
+      { subject: "CN=Android Keystore Key Attestation Root" },
+    ] as unknown as readonly X509Certificate[];
+
+    expect(isNonRkpChain(rkpChain)).toBe(false);
   });
 });

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
@@ -38,6 +38,18 @@ interface VerifyAttestationParams {
   x509Chain: readonly X509Certificate[];
 }
 
+const NON_RKP_ROOT_SUBJECT = "serialnumber=f92009e853b6b045";
+
+export const isNonRkpChain = (x509Chain: readonly X509Certificate[]) => {
+  const rootCertificate = x509Chain[x509Chain.length - 1];
+
+  const normalizedSubject = rootCertificate.subject
+    .toLowerCase()
+    .replace(/\s+/g, "");
+
+  return normalizedSubject === NON_RKP_ROOT_SUBJECT;
+};
+
 /**
  * Verifies Android key attestation by validating the certificate chain,
  * checking revocation status, and examining the key attestation extension.
@@ -62,8 +74,7 @@ export const verifyAttestation = async (
   const issuanceValidationResult = validateIssuance(
     x509Chain,
     publicKeys,
-    false,
-    true,
+    isNonRkpChain(x509Chain),
   );
 
   if (!issuanceValidationResult.success) {

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/android/attestation.ts
@@ -70,12 +70,12 @@ export const verifyAttestation = async (
 
   // 3. Verify that the root public certificate is trustworthy and that each certificate signs the next certificate in the chain.
   const publicKeys = googlePublicKeys.map(createPublicKey);
+  const isNonRkp = isNonRkpChain(x509Chain);
 
-  const issuanceValidationResult = validateIssuance(
-    x509Chain,
-    publicKeys,
-    isNonRkpChain(x509Chain),
-  );
+  const issuanceValidationResult = validateIssuance(x509Chain, publicKeys, {
+    skipIntermediateExpirationValidation: isNonRkp,
+    skipLeafAndRootExpirationValidation: true,
+  });
 
   if (!issuanceValidationResult.success) {
     return issuanceValidationResult;

--- a/apps/io-wallet-user-func/src/infra/mobile-attestation-service/ios/attestation.ts
+++ b/apps/io-wallet-user-func/src/infra/mobile-attestation-service/ios/attestation.ts
@@ -68,7 +68,10 @@ export const verifyAttestation = async (
   const issuanceValidation = validateIssuance(
     certificates,
     [rootCertificate.publicKey],
-    allowDevelopmentEnvironment,
+    {
+      skipIntermediateExpirationValidation: allowDevelopmentEnvironment,
+      skipLeafAndRootExpirationValidation: allowDevelopmentEnvironment,
+    },
   );
 
   if (!issuanceValidation.success) {


### PR DESCRIPTION
## Summary

Updates Android Key Attestation certificate validation to apply the requested RKP/Non-RKP expiration policy.

## Changes

- Detects legacy Non-RKP chains by the Android root certificate subject.
- Skips certificate validity checks for all certificates in Non-RKP chains.
- Keeps RKP validation strict for intermediate certificates while skipping leaf and root validity checks.