### PR TITLE
Add IT-Wallet firewall alerts

### DIFF
--- a/infra/core/psn/hub/prod/alerts.tf
+++ b/infra/core/psn/hub/prod/alerts.tf
@@ -1,0 +1,32 @@
+resource "azurerm_monitor_metric_alert" "firewall" {
+  provider = azurerm.hub
+
+  for_each = local.firewall_alerts
+
+  name                = "[${data.azurerm_firewall.hub.name}] ${each.value.display_name}"
+  resource_group_name = azurerm_resource_group.network.name
+  description         = each.value.description
+  severity            = 1
+  enabled             = true
+  auto_mitigate       = true
+
+  scopes = [data.azurerm_firewall.hub.id]
+
+  frequency   = "PT1M"
+  window_size = "PT5M"
+
+  criteria {
+    metric_namespace       = "Microsoft.Network/azureFirewalls"
+    metric_name            = each.value.metric_name
+    aggregation            = "Average"
+    operator               = "GreaterThan"
+    threshold              = each.value.threshold
+    skip_metric_validation = false
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.wallet.id
+  }
+
+  tags = local.tags
+}

--- a/infra/core/psn/hub/prod/data.tf
+++ b/infra/core/psn/hub/prod/data.tf
@@ -46,3 +46,15 @@ data "azurerm_public_ip" "appgw" {
   name                = "pagopa-ApplicationGW-PublicIp"
   resource_group_name = azurerm_resource_group.network.name
 }
+
+data "azurerm_firewall" "hub" {
+  provider = azurerm.hub
+
+  name                = "pagopa-afw-italynorth"
+  resource_group_name = azurerm_resource_group.network.name
+}
+
+data "azurerm_monitor_action_group" "wallet" {
+  name                = "iw-p-itn-ag-01"
+  resource_group_name = "iw-p-wallet-rg-01"
+}

--- a/infra/core/psn/hub/prod/locals.tf
+++ b/infra/core/psn/hub/prod/locals.tf
@@ -45,4 +45,43 @@ locals {
     Environment  = "PROD"
     Source       = "https://github.com/pagopa/io-wallet/blob/main/infra/core/psn/hub/prod"
   }
+
+  firewall_alerts = {
+    cpu_utilization = {
+      display_name = "High CPU utilization"
+      description  = "Azure Firewall CPU utilization exceeded 80%. Consider scaling or optimizing rule sets."
+      metric_name  = "FirewallCPUUtilization"
+      threshold    = 80
+    }
+    throughput = {
+      display_name = "High throughput"
+      description  = "Azure Firewall throughput exceeded 1000000000 Bytes/sec. Monitor for traffic saturation and performance."
+      metric_name  = "FirewallThroughput"
+      threshold    = 1000000000
+    }
+    snat_port_usage = {
+      display_name = "High SNAT port usage"
+      description  = "Azure Firewall SNAT port usage exceeded 80%. Check for SNAT exhaustion and scale accordingly."
+      metric_name  = "SNATPortUsage"
+      threshold    = 80
+    }
+    dropped_packets = {
+      display_name = "High dropped packet count"
+      description  = "Azure Firewall dropped packets exceeded 1000. Investigate rule misconfigurations or threats."
+      metric_name  = "DroppedPackets"
+      threshold    = 1000
+    }
+    allowed_packets = {
+      display_name = "High allowed packet count"
+      description  = "Azure Firewall allowed packets exceeded 100000. Ensure traffic patterns align with expectations."
+      metric_name  = "AllowedPackets"
+      threshold    = 100000
+    }
+    denied_packets = {
+      display_name = "High denied packet count"
+      description  = "Azure Firewall denied packets exceeded 500. Review denied traffic for potential threats or misconfigurations."
+      metric_name  = "DeniedPackets"
+      threshold    = 500
+    }
+  }
 }


### PR DESCRIPTION
Adds six Azure Firewall metric alerts for the PSN Hub firewall: CPU utilization, throughput, SNAT port usage, dropped packets, allowed packets, and denied packets.

Each alert is routed to the existing `iw-p-itn-ag-01` IT-Wallet action group and implements the thresholds recommended by the Microsoft assessment. Metric validation intentionally remains enabled: the current Azure supported-metrics reference differs from several assessment identifiers, so unsupported metrics cannot be silently deployed.

Resolves CES-2289